### PR TITLE
feat: Remove `--use-plonky2-backend-experimental` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 ## Overview
 
-The [blocksense.network](https://blocksense.network) team is working (as of
-April 2024) towards contributing a PLONKY2 backend to Noir. This backend can be
-used in place of brillig for proving and verifying circuits. We have reached
-the milestone where a fairly non-trivial program can be compiled and proved
-with the new PLONKY2 backend.
+The [blocksense.network](https://blocksense.network) team is working (as of May
+2024) on a PLONKY2 backend to Noir. This backend can be used for proving and
+verifying circuits. We have reached the milestone where a fairly non-trivial
+program can be compiled and proved with the new PLONKY2 backend.
 
 In order to check this for yourself follow these steps:
 
@@ -21,9 +20,8 @@ works for you too!
 
 ## Run manually
 
-To run the PLONKY2 backend manually, pass the
-`--use-plonky2-backend-experimental` flag to `nargo prove` when using it to
-construct proofs for ZK circuits written in Noir.
+To run the PLONKY2 backend manually, call `nargo prove` and construct proofs for
+ZK circuits written in Noir.
 
 ## More details
 
@@ -53,99 +51,22 @@ primitives which are then used to carry out a ZK proof.
 
 ### Backend API
 
-`tooling/nargo_cli/src/cli/prove_cmd.rs` demonstrates how the Noir compiler is
-expected to be used programmatically. There are a few steps involved:
+Historically (until 23 May 2024), Noir provided the `nargo prove` and `nargo
+verify` commands, which internally called the Barretenberg backend as a proving
+system. At the end of May 2024, the Noir team removed that feature, decoupling
+their compiler from the way the proof is performed.
 
-1. A FileManager (compiler/fm/src/lib.rs) is constructed from the project dir
-   using file_manager_with_stdlib (compiler/noirc_driver/src/lib.rs);
-2. parse_all (tooling/nargo/src/lib.rs) turns it into a ParsedFiles
-   (compiler/noirc_frontend/src/hir/mod.rs) object;
-3. compile_program (tooling/nargo/src/ops/compile.rs) produces a
-   CompiledProgram (compiler/noirc_driver/src/lib.rs) from it;
-4. prove_package (nargo_cli/src/cli/prove_cmd.rs) uses the CompiledProgram
-   object and returns a CliError or nothing on success; it takes a Backend
-   (tooling/backend_interface/src/lib.rs) object as input in order to carry out
-   the proof (calls the prove method on it and then saves the returned binary
-   to disk).
+This is an improvement for the mainline Noir workflow. At the same time, the
+PLONKY2 backend that we're developing fits more naturally with the Noir
+frontend, since it is written in Rust and called as a library rather than an
+external binary. For this reason, while Noir have removed the aforementioned
+commands, we have kept them for PLONKY2 proofs.
 
-From this structure it is obvious that the most natural way to implement a new
-backend is to implement the Backend interface and pass an instance of this new
-implementation to prove_package. This would require no changes to the general
-structure and would be the cleanest and most maintainable approach.
-
-### What we did instead
-
-The approach taken by the PLONKY2 backend implementation that we produced is the following:
-
-1. we append the data flow at step 3 from the previous section: compile_program
-   is modified to not only produce the previous program artifacts (most
-   notably, an AcirProgram [type Program defined in
-   acvm-repo/acir/src/circuit/mod.rs; renamed as AcirProgram in
-   compiler/noirc_evaluator/src/ssa.rs] object, which is the core
-   representation of the program), but also a Plonky2Circuit [new type defined
-   by our prototype], which is a duplicate representation of the program, using
-   the plonky2 primitives;
-2. we modify the control flow at step 4 from the previous section:
-   prove_package is modified to switch the control flow, depending on a new CLI
-   flag (--use-plonky2-backend-experimental). If the flag is enabled, the input
-   Backend object is ignored. Instead, the prove method on the Plonky2Circuit
-   object is called and the result from that is used when writing out the proof
-   to disk in step 4.
-
-### Why we did it this way
-
-The main reason for producing an alternative intermediate representation for
-the program (which is a bit of a hack), is that PLONKY2 has direct
-implementation for some of the intermediate-level operations, which the ACIR
-backend translates to combinations of several other operations.
-
-We wanted to enable the compilation of programs that do not depend on Brillig
-in order to avoid bloating the circuits with the additional functionality. By
-doing this, we could also avoid trying to figure out a way of implementing
-these functions (e.g. Jump, JumpIf, JumpIfNot, Call, ForeignCall, Mov,
-ConditionalMov, etc.) in PLONKY2.
-
-The following are some examples of "too much work done" by the conversion from
-SSA into ACIR which we want to avoid for our backend:
-
-1. add_var, sub_var, mul_var, and many others
-   [compiler/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs] convert
-   the respective operations into a combination of addition and multiplication
-   via the add_mul_var method; in PLONKY2, the primitives allow us to directly
-   specify many arithmetic operations, **so this conversion is something that at
-   best we could undo, but most likely will make it impossible to figure out
-   what was the original operation that lead to the produced IR**; we would need
-   this original operation to produce more efficient PLONKY2 code (with less
-   operations);
-2. div_var and mod_var represent division in target-specific ways, introducing
-   calls to Brillig functions; again, it would be infeasible to try to analyze
-   this generated code to figure out the intended operation is division, so
-   that we can generate a PLONKY2 implementation of this operation;
-3. convert_ssa_binary [compiler/noirc_evaluator/src/ssa/acir_gen/mod.rs] throws
-   an ICE for Shl and Shr (bit-shift operators); we might want to handle these
-   in our backend, but if we use this representation we won't be able to.
-
-In addition to these concerns, another consideration is that the Barretenberg
-backend is invoked as a separate binary, rather than via function calls (either
-linking the code statically or dynamically as a standalone library). While this
-is not a deal-breaker, we found it easier to deploy Noir locally if this was
-not the case. The Backend interface is designed with this implementation detail
-in place (e.g. see the assert_binary_exists
-[tooling/backend_interface/src/lib.rs] method on the interface), which
-distracts from the main purpose of the Backend interface: to carry out proofs
-and to verify them.
-
-### Recommendations
-
-We believe that it would be cleaner if what is now called Backend is renamed to
-ExternalProver for clarity. A new interface boundary called "Backend" could be
-introduced between compile_program and this new ExternalProver that lowers the
-SSA IR to an appropriate lower-level representation (either ACIR or PLONKY2 or
-the next big proving system target). In this way, there would be no need to
-duplicate the program representation as ACIR and PLONKY2 as it is currently
-done in our prototype, but the correct one could be generated and then later
-used by the ExternalProver (or a more abstract Prover, that is not necessarily
-invoked as a binary) to carry out the proof.
+In addition to the more natural fit, the user experience for the PLONKY2 backend
+is also simpler this way, when compared to requiring users to execute an
+additional step for proving or verifying their circuits. We might reconsider
+this decision in the future, but for the time being this is the path we're
+taking.
 
 the blocksense.network team
 

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -100,10 +100,6 @@ pub struct CompileOptions {
     #[arg(long, hide = true)]
     pub force_brillig: bool,
 
-    /// Force Brillig output (for step debugging)
-    #[arg(long, hide = true)]
-    pub use_plonky2_backend_experimental: bool,
-
     /// Enable the experimental elaborator pass
     #[arg(long, hide = true)]
     pub use_elaborator: bool,
@@ -286,6 +282,7 @@ pub fn compile_main(
     crate_id: CrateId,
     options: &CompileOptions,
     cached_program: Option<CompiledProgram>,
+    generate_plonky2: bool,
 ) -> CompilationResult<CompiledProgram> {
     let (_, mut warnings) = check_crate(
         context,
@@ -310,7 +307,7 @@ pub fn compile_main(
         main,
         cached_program,
         options.force_compile,
-        options.use_plonky2_backend_experimental,
+        generate_plonky2,
     )
     .map_err(FileDiagnostic::from)?;
 

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -176,7 +176,7 @@ pub fn compile_program(
     };
 
     let compiled_program =
-        noirc_driver::compile_main(&mut context, crate_id, &compile_options, None)
+        noirc_driver::compile_main(&mut context, crate_id, &compile_options, None, false)
             .map_err(|errs| {
                 CompileError::with_file_diagnostics(
                     "Failed to compile program",

--- a/compiler/wasm/src/compile_new.rs
+++ b/compiler/wasm/src/compile_new.rs
@@ -106,7 +106,7 @@ impl CompilerContext {
 
         let root_crate_id = *self.context.root_crate_id();
         let compiled_program =
-            compile_main(&mut self.context, root_crate_id, &compile_options, None)
+            compile_main(&mut self.context, root_crate_id, &compile_options, None, false)
                 .map_err(|errs| {
                     CompileError::with_file_diagnostics(
                         "Failed to compile program",

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -365,7 +365,7 @@ fn noirc_frontend_failure_{test_name}() {{
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("prove").arg("--use-plonky2-backend-experimental");
+    cmd.arg("prove");
 
     cmd.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());
             "#,
@@ -425,7 +425,7 @@ fn plonky2_prove_success_{test_name}() {{
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("prove").arg("--use-plonky2-backend-experimental");
+    cmd.arg("prove");
 
     cmd.assert().success();
 }}
@@ -465,7 +465,7 @@ fn plonky2_prove_failure_{test_name}() {{
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("prove").arg("--use-plonky2-backend-experimental");
+    cmd.arg("prove");
 
     cmd.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());"#,
             test_dir = test_dir.display(),
@@ -526,7 +526,7 @@ fn plonky2_prove_unsupported_{test_name}() {{
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("prove").arg("--use-plonky2-backend-experimental");
+    cmd.arg("prove");
 
     cmd.assert().failure().stderr(predicate::str::contains("PLONKY2 backend does not support"));
     cmd.assert().failure().stderr(predicate::str::contains("The application panicked (crashed).").not());
@@ -567,7 +567,7 @@ fn plonky2_prove_crash_{test_name}() {{
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir);
-    cmd.arg("prove").arg("--use-plonky2-backend-experimental");
+    cmd.arg("prove");
 
     cmd.assert().failure().stderr(predicate::str::contains("The application panicked (crashed)."));
 }}

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -171,7 +171,14 @@ pub(super) fn compile_workspace(
                     .filter(|p| p.noir_version == NOIR_ARTIFACT_VERSION_STRING)
                     .map(|p| p.into());
 
-            compile_program(file_manager, parsed_files, package, compile_options, cached_program)
+            compile_program(
+                file_manager,
+                parsed_files,
+                package,
+                compile_options,
+                cached_program,
+                false,
+            )
         })
         .collect();
     let contract_results: Vec<CompilationResult<CompiledContract>> = contract_packages

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -114,9 +114,17 @@ pub(crate) fn compile_bin_package_for_debugging(
             &compile_options,
             None,
             debug_state,
+            false,
         )
     } else {
-        compile_program(&workspace_file_manager, &parsed_files, package, &compile_options, None)
+        compile_program(
+            &workspace_file_manager,
+            &parsed_files,
+            package,
+            &compile_options,
+            None,
+            false,
+        )
     };
 
     report_errors(


### PR DESCRIPTION
feat: Remove `--use-plonky2-backend-experimental` flag

Now that `nargo prove` has no other implementation than ours, we remove
the flag to simplify things.

Note that the majority of `nargo` commands should still be able to skip
compilation of PLONKY2 code, since our backend is not complete and does
not support all possible operations (especially unrestricted ones).
That's why an additional argument is added to some compilation commands
that are reused throughout the system.

Also, README.md is updated to quit the yapping and plainly say how our
fork differs from upstream Noir.

Testing:

`cargo test` reports no failures;
`cd test_programs/plonky2_prove_success/zk_dungeon && nargo prove &&
nargo verify` reports no errors, so it succeeds;

Coda task: https://coda.io/d/_d6vM0kjfQP6#Blocksense-Table-View_tucZS/r754
