### PR TITLE
feat(plonky2): Check the public inputs when verifying a proof

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -70,6 +70,12 @@ impl From<Plonky2GenError> for RuntimeError {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Error)]
+pub enum Plonky2VerifyError {
+    #[error("PLONKY2 backend verification error: {}", .message)]
+    VerificationFailed { message: String },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SsaReport {
     Warning(InternalWarning),


### PR DESCRIPTION
Verify that the public inputs from the deserialized proof indeed match the expected public inputs from the Prover.toml file