### PR TITLE
feat(tracing): Add scaffolding for tracing tests

### DIFF
--- a/test_programs/plonky2_trace/1_mul
+++ b/test_programs/plonky2_trace/1_mul
@@ -1,0 +1,1 @@
+../execution_success/1_mul/

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -44,6 +44,7 @@ fn main() {
     // generate_plonky2_prove_crash_tests(&mut test_file, &test_dir);
     generate_plonky2_verify_success_tests(&mut test_file, &test_dir);
     generate_plonky2_verify_failure_tests(&mut test_file, &test_dir);
+    generate_plonky2_trace_tests(&mut test_file, &test_dir);
 }
 
 /// Some tests are explicitly ignored in brillig due to them failing.
@@ -805,6 +806,66 @@ fn plonky2_verify_failure_{test_name}() {{
                         test_file,
                         r#"
     cmd2.assert().failure().stderr(predicate::str::contains("{message}"));"#
+                    )
+                    .expect("Could not write templated test file.");
+                }
+            }
+            None => {}
+        }
+
+        write!(
+            test_file,
+            r#"
+}}
+"#
+        )
+        .expect("Could not write templated test file.");
+    }
+}
+
+fn generate_plonky2_trace_tests(test_file: &mut File, test_data_dir: &Path) {
+    let test_sub_dir = "plonky2_trace";
+    let test_data_dir = test_data_dir.join(test_sub_dir);
+
+    let test_case_dirs =
+        fs::read_dir(test_data_dir).unwrap().flatten().filter(|c| c.path().is_dir());
+
+    let expected_messages = HashMap::from([("1_mul", vec!["Total tracing steps: 14"])]);
+
+    for test_dir in test_case_dirs {
+        let test_name =
+            test_dir.file_name().into_string().expect("Directory can't be converted to string");
+        if test_name.contains('-') {
+            panic!(
+                "Invalid test directory: {test_name}. Cannot include `-`, please convert to `_`"
+            );
+        };
+        let test_dir = &test_dir.path();
+
+        write!(
+            test_file,
+            r#"
+#[test]
+fn plonky2_trace_{test_name}() {{
+    let test_program_dir = PathBuf::from("{test_dir}");
+
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("--program-dir").arg(test_program_dir.clone());
+    cmd.arg("trace").arg("--trace-dir").arg("it-does-not-matter-yet");
+
+    cmd.assert().success();"#,
+            test_dir = test_dir.display(),
+        )
+        .expect("Could not write templated test file.");
+
+        // Not all tests have expected messages, so match.
+        match expected_messages.get(test_name.as_str()) {
+            Some(messages) => {
+                for message in messages.iter() {
+                    write!(
+                        test_file,
+                        r#"
+    cmd.assert().success().stdout(predicate::str::contains("{message}"));"#
                     )
                     .expect("Could not write templated test file.");
                 }


### PR DESCRIPTION
This scaffolding allows the additions of tests for `nargo trace` in the same vein as tests are added for other nargo commands.

To check locally what this PR does, checkout the repo and run

`cargo test plonky2_trace`

It should result in a single test running successfully.

To convince yourself that the test is real, try changing the info message printed in `tooling/tracer/src/lib.rs:117` and running the test again.

Note: there is no actual tracing logic yet, but this will be added in
following commits.