### PR TITLE
feat(plonky2): Converted the sha256 intrinsic codegen to use the new AsmWriter

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
@@ -38,4 +38,5 @@ pub trait AsmWriter {
     fn add_virtual_bool_target_unsafe(&mut self) -> BoolTarget;
     fn constant_u32(&mut self, c: u32) -> U32Target;
     fn add_u32(&mut self, a: U32Target, b: U32Target) -> (U32Target, U32Target);
+    fn split_le_base<const B: usize>(&mut self, x: Target, num_limbs: usize) -> Vec<Target>;
 }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
@@ -1,6 +1,7 @@
 use std::borrow::Borrow;
 
 use plonky2::iop::target::{BoolTarget, Target};
+use plonky2_u32::gadgets::arithmetic_u32::U32Target;
 
 use super::config::{P2Builder, P2Field};
 
@@ -34,4 +35,6 @@ pub trait AsmWriter {
         T: Borrow<Target>;
     fn le_sum(&mut self, bits: impl Iterator<Item = impl Borrow<BoolTarget>> + Clone) -> Target;
     fn range_check(&mut self, x: Target, n_log: usize);
+    fn add_virtual_bool_target_unsafe(&mut self) -> BoolTarget;
+    fn constant_u32(&mut self, c: u32) -> U32Target;
 }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
@@ -37,4 +37,5 @@ pub trait AsmWriter {
     fn range_check(&mut self, x: Target, n_log: usize);
     fn add_virtual_bool_target_unsafe(&mut self) -> BoolTarget;
     fn constant_u32(&mut self, c: u32) -> U32Target;
+    fn add_u32(&mut self, a: U32Target, b: U32Target) -> (U32Target, U32Target);
 }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
@@ -402,4 +402,18 @@ impl AsmWriter for ConsoleAsmWriter {
         }
         result
     }
+
+    fn add_u32(&mut self, a: U32Target, b: U32Target) -> (U32Target, U32Target) {
+        let result = self.builder.add_u32(a, b);
+        if self.show_plonky2 {
+            println!(
+                "add_u32\t{},{},({},{})",
+                U32TargetDisplay { t: a },
+                U32TargetDisplay { t: b },
+                U32TargetDisplay { t: result.0 },
+                U32TargetDisplay { t: result.1 }
+            );
+        }
+        result
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
@@ -4,6 +4,7 @@ use plonky2::iop::{
     target::{BoolTarget, Target},
     wire::Wire,
 };
+use plonky2_u32::gadgets::arithmetic_u32::{CircuitBuilderU32, U32Target};
 
 use super::config::P2Field;
 use super::{asm_writer::AsmWriter, config::P2Builder};
@@ -128,6 +129,16 @@ impl<TIter: Iterator<Item = T> + Clone, T: Borrow<BoolTarget>> Display
         }
         write!(f, ")")?;
         Ok(())
+    }
+}
+
+struct U32TargetDisplay {
+    t: U32Target,
+}
+
+impl Display for U32TargetDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", TargetDisplay { t: self.t.0 })
     }
 }
 
@@ -374,5 +385,21 @@ impl AsmWriter for ConsoleAsmWriter {
         if self.show_plonky2 {
             println!("range_check\t{},{}", TargetDisplay { t: x }, n_log);
         }
+    }
+
+    fn add_virtual_bool_target_unsafe(&mut self) -> BoolTarget {
+        let result = self.builder.add_virtual_bool_target_unsafe();
+        if self.show_plonky2 {
+            println!("add_virtual_bool_target_unsafe\t{}", BoolTargetDisplay { t: result });
+        }
+        result
+    }
+
+    fn constant_u32(&mut self, c: u32) -> U32Target {
+        let result = self.builder.constant_u32(c);
+        if self.show_plonky2 {
+            println!("constant_u32\t{},{}", c, U32TargetDisplay { t: result });
+        }
+        result
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
@@ -25,6 +25,26 @@ impl Display for TargetDisplay {
         }
     }
 }
+struct VecTargetDisplay<'a> {
+    t: &'a Vec<Target>,
+}
+
+impl<'a> Display for VecTargetDisplay<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "(")?;
+        let mut first = true;
+        for tt in self.t {
+            if first {
+                write!(f, "{}", TargetDisplay { t: *tt })?;
+                first = false;
+            } else {
+                write!(f, ",{}", TargetDisplay { t: *tt })?;
+            }
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
 
 struct BoolTargetDisplay {
     t: BoolTarget,
@@ -413,6 +433,20 @@ impl AsmWriter for ConsoleAsmWriter {
                 U32TargetDisplay { t: result.0 },
                 U32TargetDisplay { t: result.1 }
             );
+        }
+        result
+    }
+
+    fn split_le_base<const B: usize>(&mut self, x: Target, num_limbs: usize) -> Vec<Target> {
+        let result = self.builder.split_le_base::<B>(x, num_limbs);
+        if self.show_plonky2 {
+            println!(
+                "split_le_base\t{},{},{},{}",
+                B,
+                TargetDisplay { t: x },
+                num_limbs,
+                VecTargetDisplay { t: &result }
+            )
         }
         result
     }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/intrinsics/sha256.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/intrinsics/sha256.rs
@@ -48,21 +48,21 @@ fn array_to_bits(bytes: &[u8]) -> Vec<bool> {
 }
 
 fn u32_to_bits_target<const B: usize>(
-    builder: &mut impl AsmWriter,
+    asm_writer: &mut impl AsmWriter,
     a: &U32Target,
 ) -> Vec<BoolTarget> {
     let mut res = Vec::new();
-    let bit_targets = builder.split_le_base::<B>(a.0, 32);
+    let bit_targets = asm_writer.split_le_base::<B>(a.0, 32);
     for i in (0..32).rev() {
         res.push(BoolTarget::new_unsafe(bit_targets[i]));
     }
     res
 }
 
-fn bits_to_u32_target(builder: &mut impl AsmWriter, bits_target: Vec<BoolTarget>) -> U32Target {
+fn bits_to_u32_target(asm_writer: &mut impl AsmWriter, bits_target: Vec<BoolTarget>) -> U32Target {
     let bit_len = bits_target.len();
     assert_eq!(bit_len, 32);
-    U32Target(builder.le_sum(bits_target[0..32].iter().rev()))
+    U32Target(asm_writer.le_sum(bits_target[0..32].iter().rev()))
 }
 
 // define ROTATE(x, y)  (((x)>>(y)) | ((x)<<(32-(y))))
@@ -96,93 +96,93 @@ a ^ b ^ c = a+b+c - 2*a*b - 2*a*c - 2*b*c + 4*a*b*c
           = a*( 1 - 2*b -2*c + 4*m ) + b + c - 2*m
 where m = b*c
  */
-fn xor3(builder: &mut impl AsmWriter, a: BoolTarget, b: BoolTarget, c: BoolTarget) -> BoolTarget {
-    let m = builder.mul(b.target, c.target);
-    let two_b = builder.add(b.target, b.target);
-    let two_c = builder.add(c.target, c.target);
-    let two_m = builder.add(m, m);
-    let four_m = builder.add(two_m, two_m);
-    let one = builder.one();
-    let one_sub_two_b = builder.sub(one, two_b);
-    let one_sub_two_b_sub_two_c = builder.sub(one_sub_two_b, two_c);
-    let one_sub_two_b_sub_two_c_add_four_m = builder.add(one_sub_two_b_sub_two_c, four_m);
-    let mut res = builder.mul(a.target, one_sub_two_b_sub_two_c_add_four_m);
-    res = builder.add(res, b.target);
-    res = builder.add(res, c.target);
+fn xor3(asm_writer: &mut impl AsmWriter, a: BoolTarget, b: BoolTarget, c: BoolTarget) -> BoolTarget {
+    let m = asm_writer.mul(b.target, c.target);
+    let two_b = asm_writer.add(b.target, b.target);
+    let two_c = asm_writer.add(c.target, c.target);
+    let two_m = asm_writer.add(m, m);
+    let four_m = asm_writer.add(two_m, two_m);
+    let one = asm_writer.one();
+    let one_sub_two_b = asm_writer.sub(one, two_b);
+    let one_sub_two_b_sub_two_c = asm_writer.sub(one_sub_two_b, two_c);
+    let one_sub_two_b_sub_two_c_add_four_m = asm_writer.add(one_sub_two_b_sub_two_c, four_m);
+    let mut res = asm_writer.mul(a.target, one_sub_two_b_sub_two_c_add_four_m);
+    res = asm_writer.add(res, b.target);
+    res = asm_writer.add(res, c.target);
 
-    BoolTarget::new_unsafe(builder.sub(res, two_m))
+    BoolTarget::new_unsafe(asm_writer.sub(res, two_m))
 }
 
 //#define Sigma0(x)    (ROTATE((x), 2) ^ ROTATE((x),13) ^ ROTATE((x),22))
-fn big_sigma0(builder: &mut impl AsmWriter, a: &U32Target) -> U32Target {
-    let a_bits = u32_to_bits_target::<2>(builder, a);
+fn big_sigma0(asm_writer: &mut impl AsmWriter, a: &U32Target) -> U32Target {
+    let a_bits = u32_to_bits_target::<2>(asm_writer, a);
     let rotate2 = rotate32(2);
     let rotate13 = rotate32(13);
     let rotate22 = rotate32(22);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        res_bits.push(xor3(builder, a_bits[rotate2[i]], a_bits[rotate13[i]], a_bits[rotate22[i]]));
+        res_bits.push(xor3(asm_writer, a_bits[rotate2[i]], a_bits[rotate13[i]], a_bits[rotate22[i]]));
     }
-    bits_to_u32_target(builder, res_bits)
+    bits_to_u32_target(asm_writer, res_bits)
 }
 
 //#define Sigma1(x)    (ROTATE((x), 6) ^ ROTATE((x),11) ^ ROTATE((x),25))
-fn big_sigma1(builder: &mut impl AsmWriter, a: &U32Target) -> U32Target {
-    let a_bits = u32_to_bits_target::<2>(builder, a);
+fn big_sigma1(asm_writer: &mut impl AsmWriter, a: &U32Target) -> U32Target {
+    let a_bits = u32_to_bits_target::<2>(asm_writer, a);
     let rotate6 = rotate32(6);
     let rotate11 = rotate32(11);
     let rotate25 = rotate32(25);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        res_bits.push(xor3(builder, a_bits[rotate6[i]], a_bits[rotate11[i]], a_bits[rotate25[i]]));
+        res_bits.push(xor3(asm_writer, a_bits[rotate6[i]], a_bits[rotate11[i]], a_bits[rotate25[i]]));
     }
-    bits_to_u32_target(builder, res_bits)
+    bits_to_u32_target(asm_writer, res_bits)
 }
 
 //#define sigma0(x)    (ROTATE((x), 7) ^ ROTATE((x),18) ^ ((x)>> 3))
-fn sigma0(builder: &mut impl AsmWriter, a: &U32Target) -> U32Target {
-    let mut a_bits = u32_to_bits_target::<2>(builder, a);
-    a_bits.push(builder.constant_bool(false));
+fn sigma0(asm_writer: &mut impl AsmWriter, a: &U32Target) -> U32Target {
+    let mut a_bits = u32_to_bits_target::<2>(asm_writer, a);
+    a_bits.push(asm_writer.constant_bool(false));
     let rotate7 = rotate32(7);
     let rotate18 = rotate32(18);
     let shift3 = shift32(3);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        res_bits.push(xor3(builder, a_bits[rotate7[i]], a_bits[rotate18[i]], a_bits[shift3[i]]));
+        res_bits.push(xor3(asm_writer, a_bits[rotate7[i]], a_bits[rotate18[i]], a_bits[shift3[i]]));
     }
-    bits_to_u32_target(builder, res_bits)
+    bits_to_u32_target(asm_writer, res_bits)
 }
 
 //#define sigma1(x)    (ROTATE((x),17) ^ ROTATE((x),19) ^ ((x)>>10))
-fn sigma1(builder: &mut impl AsmWriter, a: &U32Target) -> U32Target {
-    let mut a_bits = u32_to_bits_target::<2>(builder, a);
-    a_bits.push(builder.constant_bool(false));
+fn sigma1(asm_writer: &mut impl AsmWriter, a: &U32Target) -> U32Target {
+    let mut a_bits = u32_to_bits_target::<2>(asm_writer, a);
+    a_bits.push(asm_writer.constant_bool(false));
     let rotate17 = rotate32(17);
     let rotate19 = rotate32(19);
     let shift10 = shift32(10);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        res_bits.push(xor3(builder, a_bits[rotate17[i]], a_bits[rotate19[i]], a_bits[shift10[i]]));
+        res_bits.push(xor3(asm_writer, a_bits[rotate17[i]], a_bits[rotate19[i]], a_bits[shift10[i]]));
     }
-    bits_to_u32_target(builder, res_bits)
+    bits_to_u32_target(asm_writer, res_bits)
 }
 
 /*
 ch = a&b ^ (!a)&c
    = a*(b-c) + c
  */
-fn ch(builder: &mut impl AsmWriter, a: &U32Target, b: &U32Target, c: &U32Target) -> U32Target {
-    let a_bits = u32_to_bits_target::<2>(builder, a);
-    let b_bits = u32_to_bits_target::<2>(builder, b);
-    let c_bits = u32_to_bits_target::<2>(builder, c);
+fn ch(asm_writer: &mut impl AsmWriter, a: &U32Target, b: &U32Target, c: &U32Target) -> U32Target {
+    let a_bits = u32_to_bits_target::<2>(asm_writer, a);
+    let b_bits = u32_to_bits_target::<2>(asm_writer, b);
+    let c_bits = u32_to_bits_target::<2>(asm_writer, c);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        let b_sub_c = builder.sub(b_bits[i].target, c_bits[i].target);
-        let a_mul_b_sub_c = builder.mul(a_bits[i].target, b_sub_c);
-        let a_mul_b_sub_c_add_c = builder.add(a_mul_b_sub_c, c_bits[i].target);
+        let b_sub_c = asm_writer.sub(b_bits[i].target, c_bits[i].target);
+        let a_mul_b_sub_c = asm_writer.mul(a_bits[i].target, b_sub_c);
+        let a_mul_b_sub_c_add_c = asm_writer.add(a_mul_b_sub_c, c_bits[i].target);
         res_bits.push(BoolTarget::new_unsafe(a_mul_b_sub_c_add_c));
     }
-    bits_to_u32_target(builder, res_bits)
+    bits_to_u32_target(asm_writer, res_bits)
 }
 
 /*
@@ -192,27 +192,27 @@ maj = a&b ^ a&c ^ b&c
     = a*( b + c - 2*m ) + m
 where m = b*c
  */
-fn maj(builder: &mut impl AsmWriter, a: &U32Target, b: &U32Target, c: &U32Target) -> U32Target {
-    let a_bits = u32_to_bits_target::<2>(builder, a);
-    let b_bits = u32_to_bits_target::<2>(builder, b);
-    let c_bits = u32_to_bits_target::<2>(builder, c);
+fn maj(asm_writer: &mut impl AsmWriter, a: &U32Target, b: &U32Target, c: &U32Target) -> U32Target {
+    let a_bits = u32_to_bits_target::<2>(asm_writer, a);
+    let b_bits = u32_to_bits_target::<2>(asm_writer, b);
+    let c_bits = u32_to_bits_target::<2>(asm_writer, c);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        let m = builder.mul(b_bits[i].target, c_bits[i].target);
-        let two = builder.two();
-        let two_m = builder.mul(two, m);
-        let b_add_c = builder.add(b_bits[i].target, c_bits[i].target);
-        let b_add_c_sub_two_m = builder.sub(b_add_c, two_m);
-        let a_mul_b_add_c_sub_two_m = builder.mul(a_bits[i].target, b_add_c_sub_two_m);
-        let res = builder.add(a_mul_b_add_c_sub_two_m, m);
+        let m = asm_writer.mul(b_bits[i].target, c_bits[i].target);
+        let two = asm_writer.two();
+        let two_m = asm_writer.mul(two, m);
+        let b_add_c = asm_writer.add(b_bits[i].target, c_bits[i].target);
+        let b_add_c_sub_two_m = asm_writer.sub(b_add_c, two_m);
+        let a_mul_b_add_c_sub_two_m = asm_writer.mul(a_bits[i].target, b_add_c_sub_two_m);
+        let res = asm_writer.add(a_mul_b_add_c_sub_two_m, m);
 
         res_bits.push(BoolTarget::new_unsafe(res));
     }
-    bits_to_u32_target(builder, res_bits)
+    bits_to_u32_target(asm_writer, res_bits)
 }
 
-fn add_u32(builder: &mut impl AsmWriter, a: &U32Target, b: &U32Target) -> U32Target {
-    let (res, _carry) = builder.add_u32(*a, *b);
+fn add_u32(asm_writer: &mut impl AsmWriter, a: &U32Target, b: &U32Target) -> U32Target {
+    let (res, _carry) = asm_writer.add_u32(*a, *b);
     res
 }
 
@@ -220,7 +220,7 @@ fn add_u32(builder: &mut impl AsmWriter, a: &U32Target, b: &U32Target) -> U32Tar
 // Size: msg_len_in_bits (L) |  p bits   | 64 bits
 // Bits:      msg            | 100...000 |    L
 pub(crate) fn make_sha256_circuit(
-    builder: &mut impl AsmWriter,
+    asm_writer: &mut impl AsmWriter,
     msg_len_in_bits: u64,
 ) -> Sha256Targets {
     let mut message = Vec::new();
@@ -231,26 +231,26 @@ pub(crate) fn make_sha256_circuit(
     assert!(p > 1);
 
     for _ in 0..msg_len_in_bits {
-        message.push(builder.add_virtual_bool_target_unsafe());
+        message.push(asm_writer.add_virtual_bool_target_unsafe());
     }
-    message.push(builder.constant_bool(true));
+    message.push(asm_writer.constant_bool(true));
     for _ in 0..p - 1 {
-        message.push(builder.constant_bool(false));
+        message.push(asm_writer.constant_bool(false));
     }
     for i in 0..64 {
         let b = ((msg_len_in_bits as u64) >> (63 - i)) & 1;
-        message.push(builder.constant_bool(b == 1));
+        message.push(asm_writer.constant_bool(b == 1));
     }
 
     // init states
     let mut state = Vec::new();
     for i in 0..8 {
-        state.push(builder.constant_u32(H256[i]));
+        state.push(asm_writer.constant_u32(H256[i]));
     }
 
     let mut k256 = Vec::new();
     for i in 0..64 {
-        k256.push(builder.constant_u32(K256[i]));
+        k256.push(asm_writer.constant_u32(K256[i]));
     }
 
     for blk in 0..block_count {
@@ -266,74 +266,74 @@ pub(crate) fn make_sha256_circuit(
 
         for i in 0..16 {
             let index = blk as usize * 512 + i * 32;
-            let u32_target = builder.le_sum(message[index..index + 32].iter().rev());
+            let u32_target = asm_writer.le_sum(message[index..index + 32].iter().rev());
 
             x.push(U32Target(u32_target));
             let mut t1 = h.clone();
-            let big_sigma1_e = big_sigma1(builder, &e);
-            t1 = add_u32(builder, &t1, &big_sigma1_e);
-            let ch_e_f_g = ch(builder, &e, &f, &g);
-            t1 = add_u32(builder, &t1, &ch_e_f_g);
-            t1 = add_u32(builder, &t1, &k256[i]);
-            t1 = add_u32(builder, &t1, &x[i]);
+            let big_sigma1_e = big_sigma1(asm_writer, &e);
+            t1 = add_u32(asm_writer, &t1, &big_sigma1_e);
+            let ch_e_f_g = ch(asm_writer, &e, &f, &g);
+            t1 = add_u32(asm_writer, &t1, &ch_e_f_g);
+            t1 = add_u32(asm_writer, &t1, &k256[i]);
+            t1 = add_u32(asm_writer, &t1, &x[i]);
 
-            let mut t2 = big_sigma0(builder, &a);
-            let maj_a_b_c = maj(builder, &a, &b, &c);
-            t2 = add_u32(builder, &t2, &maj_a_b_c);
+            let mut t2 = big_sigma0(asm_writer, &a);
+            let maj_a_b_c = maj(asm_writer, &a, &b, &c);
+            t2 = add_u32(asm_writer, &t2, &maj_a_b_c);
 
             h = g;
             g = f;
             f = e;
-            e = add_u32(builder, &d, &t1);
+            e = add_u32(asm_writer, &d, &t1);
             d = c;
             c = b;
             b = a;
-            a = add_u32(builder, &t1, &t2);
+            a = add_u32(asm_writer, &t1, &t2);
         }
 
         for i in 16..64 {
-            let s0 = sigma0(builder, &x[(i + 1) & 0x0f]);
-            let s1 = sigma1(builder, &x[(i + 14) & 0x0f]);
+            let s0 = sigma0(asm_writer, &x[(i + 1) & 0x0f]);
+            let s1 = sigma1(asm_writer, &x[(i + 14) & 0x0f]);
 
-            let s0_add_s1 = add_u32(builder, &s0, &s1);
-            let s0_add_s1_add_x = add_u32(builder, &s0_add_s1, &x[(i + 9) & 0xf]);
-            x[i & 0xf] = add_u32(builder, &x[i & 0xf], &s0_add_s1_add_x);
+            let s0_add_s1 = add_u32(asm_writer, &s0, &s1);
+            let s0_add_s1_add_x = add_u32(asm_writer, &s0_add_s1, &x[(i + 9) & 0xf]);
+            x[i & 0xf] = add_u32(asm_writer, &x[i & 0xf], &s0_add_s1_add_x);
 
-            let big_sigma0_a = big_sigma0(builder, &a);
-            let big_sigma1_e = big_sigma1(builder, &e);
-            let ch_e_f_g = ch(builder, &e, &f, &g);
-            let maj_a_b_c = maj(builder, &a, &b, &c);
+            let big_sigma0_a = big_sigma0(asm_writer, &a);
+            let big_sigma1_e = big_sigma1(asm_writer, &e);
+            let ch_e_f_g = ch(asm_writer, &e, &f, &g);
+            let maj_a_b_c = maj(asm_writer, &a, &b, &c);
 
-            let h_add_sigma1 = add_u32(builder, &h, &big_sigma1_e);
-            let h_add_sigma1_add_ch_e_f_g = add_u32(builder, &h_add_sigma1, &ch_e_f_g);
+            let h_add_sigma1 = add_u32(asm_writer, &h, &big_sigma1_e);
+            let h_add_sigma1_add_ch_e_f_g = add_u32(asm_writer, &h_add_sigma1, &ch_e_f_g);
             let h_add_sigma1_add_ch_e_f_g_add_k256 =
-                add_u32(builder, &h_add_sigma1_add_ch_e_f_g, &k256[i]);
+                add_u32(asm_writer, &h_add_sigma1_add_ch_e_f_g, &k256[i]);
 
-            let t1 = add_u32(builder, &x[i & 0xf], &h_add_sigma1_add_ch_e_f_g_add_k256);
-            let t2 = add_u32(builder, &big_sigma0_a, &maj_a_b_c);
+            let t1 = add_u32(asm_writer, &x[i & 0xf], &h_add_sigma1_add_ch_e_f_g_add_k256);
+            let t2 = add_u32(asm_writer, &big_sigma0_a, &maj_a_b_c);
 
             h = g;
             g = f;
             f = e;
-            e = add_u32(builder, &d, &t1);
+            e = add_u32(asm_writer, &d, &t1);
             d = c;
             c = b;
             b = a;
-            a = add_u32(builder, &t1, &t2);
+            a = add_u32(asm_writer, &t1, &t2);
         }
 
-        state[0] = add_u32(builder, &state[0], &a);
-        state[1] = add_u32(builder, &state[1], &b);
-        state[2] = add_u32(builder, &state[2], &c);
-        state[3] = add_u32(builder, &state[3], &d);
-        state[4] = add_u32(builder, &state[4], &e);
-        state[5] = add_u32(builder, &state[5], &f);
-        state[6] = add_u32(builder, &state[6], &g);
-        state[7] = add_u32(builder, &state[7], &h);
+        state[0] = add_u32(asm_writer, &state[0], &a);
+        state[1] = add_u32(asm_writer, &state[1], &b);
+        state[2] = add_u32(asm_writer, &state[2], &c);
+        state[3] = add_u32(asm_writer, &state[3], &d);
+        state[4] = add_u32(asm_writer, &state[4], &e);
+        state[5] = add_u32(asm_writer, &state[5], &f);
+        state[6] = add_u32(asm_writer, &state[6], &g);
+        state[7] = add_u32(asm_writer, &state[7], &h);
     }
 
     for i in 0..8 {
-        let bit_targets = builder.split_le_base::<2>(state[i].0, 32);
+        let bit_targets = asm_writer.split_le_base::<2>(state[i].0, 32);
         for j in (0..32).rev() {
             digest.push(BoolTarget::new_unsafe(bit_targets[j]));
         }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/intrinsics/sha256.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/intrinsics/sha256.rs
@@ -96,7 +96,12 @@ a ^ b ^ c = a+b+c - 2*a*b - 2*a*c - 2*b*c + 4*a*b*c
           = a*( 1 - 2*b -2*c + 4*m ) + b + c - 2*m
 where m = b*c
  */
-fn xor3(asm_writer: &mut impl AsmWriter, a: BoolTarget, b: BoolTarget, c: BoolTarget) -> BoolTarget {
+fn xor3(
+    asm_writer: &mut impl AsmWriter,
+    a: BoolTarget,
+    b: BoolTarget,
+    c: BoolTarget,
+) -> BoolTarget {
     let m = asm_writer.mul(b.target, c.target);
     let two_b = asm_writer.add(b.target, b.target);
     let two_c = asm_writer.add(c.target, c.target);
@@ -121,7 +126,12 @@ fn big_sigma0(asm_writer: &mut impl AsmWriter, a: &U32Target) -> U32Target {
     let rotate22 = rotate32(22);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        res_bits.push(xor3(asm_writer, a_bits[rotate2[i]], a_bits[rotate13[i]], a_bits[rotate22[i]]));
+        res_bits.push(xor3(
+            asm_writer,
+            a_bits[rotate2[i]],
+            a_bits[rotate13[i]],
+            a_bits[rotate22[i]],
+        ));
     }
     bits_to_u32_target(asm_writer, res_bits)
 }
@@ -134,7 +144,12 @@ fn big_sigma1(asm_writer: &mut impl AsmWriter, a: &U32Target) -> U32Target {
     let rotate25 = rotate32(25);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        res_bits.push(xor3(asm_writer, a_bits[rotate6[i]], a_bits[rotate11[i]], a_bits[rotate25[i]]));
+        res_bits.push(xor3(
+            asm_writer,
+            a_bits[rotate6[i]],
+            a_bits[rotate11[i]],
+            a_bits[rotate25[i]],
+        ));
     }
     bits_to_u32_target(asm_writer, res_bits)
 }
@@ -162,7 +177,12 @@ fn sigma1(asm_writer: &mut impl AsmWriter, a: &U32Target) -> U32Target {
     let shift10 = shift32(10);
     let mut res_bits = Vec::new();
     for i in 0..32 {
-        res_bits.push(xor3(asm_writer, a_bits[rotate17[i]], a_bits[rotate19[i]], a_bits[shift10[i]]));
+        res_bits.push(xor3(
+            asm_writer,
+            a_bits[rotate17[i]],
+            a_bits[rotate19[i]],
+            a_bits[shift10[i]],
+        ));
     }
     bits_to_u32_target(asm_writer, res_bits)
 }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/intrinsics/sha256.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/intrinsics/sha256.rs
@@ -1,7 +1,7 @@
 use plonky2::iop::target::BoolTarget;
-use plonky2_u32::gadgets::arithmetic_u32::{CircuitBuilderU32, U32Target};
+use plonky2_u32::gadgets::arithmetic_u32::U32Target;
 
-use crate::ssa::plonky2_gen::{asm_writer::AsmWriter, config::P2Builder};
+use crate::ssa::plonky2_gen::asm_writer::AsmWriter;
 
 #[rustfmt::skip]
 const H256: [u32; 8] = [

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
@@ -529,7 +529,7 @@ where
         };
         */
         let msg_len = u64::try_from(argument.1.len()).unwrap() * 8;
-        let sha256targets = make_sha256_circuit(&mut self.get_mut_builder(), msg_len);
+        let sha256targets = make_sha256_circuit(&mut self.asm_writer, msg_len);
         let mut j = 0;
         for target in argument.1 {
             let split_arg = self.asm_writer.split_le(target.get_target()?, 8);


### PR DESCRIPTION
This makes the operations generated by the PLONKY2 sha256 intrinsic code generator visible via the '--show-plonky2' command line option. Additionally, the following operations were introduced to the AsmWriter:

add_virtual_bool_target_unsafe
constant_u32
add_u32
split_le_base