### PR TITLE
feat(plonky2): converted the remaining parts of the PLONKY2 code generator to use the AsmWriter

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
@@ -39,4 +39,5 @@ pub trait AsmWriter {
     fn constant_u32(&mut self, c: u32) -> U32Target;
     fn add_u32(&mut self, a: U32Target, b: U32Target) -> (U32Target, U32Target);
     fn split_le_base<const B: usize>(&mut self, x: Target, num_limbs: usize) -> Vec<Target>;
+    fn add_virtual_target(&mut self) -> Target;
 }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/asm_writer.rs
@@ -36,6 +36,7 @@ pub trait AsmWriter {
     fn le_sum(&mut self, bits: impl Iterator<Item = impl Borrow<BoolTarget>> + Clone) -> Target;
     fn range_check(&mut self, x: Target, n_log: usize);
     fn add_virtual_bool_target_unsafe(&mut self) -> BoolTarget;
+    fn add_virtual_bool_target_safe(&mut self) -> BoolTarget;
     fn constant_u32(&mut self, c: u32) -> U32Target;
     fn add_u32(&mut self, a: U32Target, b: U32Target) -> (U32Target, U32Target);
     fn split_le_base<const B: usize>(&mut self, x: Target, num_limbs: usize) -> Vec<Target>;

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
@@ -450,4 +450,12 @@ impl AsmWriter for ConsoleAsmWriter {
         }
         result
     }
+
+    fn add_virtual_target(&mut self) -> Target {
+        let result = self.builder.add_virtual_target();
+        if self.show_plonky2 {
+            println!("add_virtual_target\t{}", TargetDisplay { t: result });
+        }
+        result
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/console_asm_writer.rs
@@ -415,6 +415,14 @@ impl AsmWriter for ConsoleAsmWriter {
         result
     }
 
+    fn add_virtual_bool_target_safe(&mut self) -> BoolTarget {
+        let result = self.builder.add_virtual_bool_target_safe();
+        if self.show_plonky2 {
+            println!("add_virtual_bool_target_safe\t{}", BoolTargetDisplay { t: result });
+        }
+        result
+    }
+
     fn constant_u32(&mut self, c: u32) -> U32Target {
         let result = self.builder.constant_u32(c);
         if self.show_plonky2 {

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/div_generator.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/div_generator.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use std::marker::PhantomData;
 
-use super::{asm_writer::AsmWriter, config::{P2Builder, P2Field}};
+use super::{asm_writer::AsmWriter, config::P2Field};
 use plonky2::{
     field::types::{Field, PrimeField64},
     iop::{

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/div_generator.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/div_generator.rs
@@ -28,8 +28,8 @@ impl VariableIntDivGenerator {
         Self {
             numerator,
             denominator,
-            quotient: asm_writer.get_mut_builder().add_virtual_target(),
-            remainder: asm_writer.get_mut_builder().add_virtual_target(),
+            quotient: asm_writer.add_virtual_target(),
+            remainder: asm_writer.add_virtual_target(),
             _phantom: PhantomData,
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
@@ -123,12 +123,14 @@ impl P2Value {
     /// builder.
     fn create_empty(asm_writer: &mut impl AsmWriter, p2type: P2Type) -> P2Value {
         match p2type.clone() {
-            P2Type::Field => {
-                P2Value { target: P2Target::IntTarget(asm_writer.add_virtual_target()), typ: p2type }
-            }
-            P2Type::Integer(_) => {
-                P2Value { target: P2Target::IntTarget(asm_writer.add_virtual_target()), typ: p2type }
-            }
+            P2Type::Field => P2Value {
+                target: P2Target::IntTarget(asm_writer.add_virtual_target()),
+                typ: p2type,
+            },
+            P2Type::Integer(_) => P2Value {
+                target: P2Target::IntTarget(asm_writer.add_virtual_target()),
+                typ: p2type,
+            },
             P2Type::Boolean => P2Value {
                 target: P2Target::BoolTarget(asm_writer.add_virtual_bool_target_safe()),
                 typ: p2type,

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
@@ -320,13 +320,6 @@ where
         }
     }
 
-    fn get_builder(&self) -> &P2Builder {
-        self.asm_writer.get_builder()
-    }
-    fn get_mut_builder(&mut self) -> &mut P2Builder {
-        self.asm_writer.get_mut_builder()
-    }
-
     pub(crate) fn build(
         mut self,
         ssa: Ssa,

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
@@ -823,7 +823,7 @@ where
                         return Err(Plonky2GenError::UnsupportedFeature { name: feature_name });
                     }
                 };
-                let new_target = self.get_mut_builder().add_virtual_target();
+                let new_target = self.asm_writer.add_virtual_target();
                 self.asm_writer.connect(target, new_target);
 
                 let p2value = P2Value::make_integer(P2Type::Integer(bit_size), new_target)?;


### PR DESCRIPTION
After these changes, all plonky2 calls should (in theory) be printed to the screen by the '--show-plonky2' command line option.