### PR TITLE
chore: applied 'cargo fmt'. No functional changes.

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -562,10 +562,8 @@ pub fn compile_no_check(
         force_brillig_output: options.force_brillig,
         print_codegen_timings: options.benchmark_codegen,
     };
-    let SsaProgramArtifact { program, debug, warnings, names, error_types, .. } = create_program(
-        monomorph.clone(),
-        &ssa_evaluator_options
-    )?;
+    let SsaProgramArtifact { program, debug, warnings, names, error_types, .. } =
+        create_program(monomorph.clone(), &ssa_evaluator_options)?;
 
     let abi = abi_gen::gen_abi(context, &main_function, return_visibility, error_types);
     let file_map = filter_relevant_files(&debug, &context.file_manager);

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/config.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/config.rs
@@ -2,8 +2,7 @@ use plonky2::{
     field::goldilocks_field::GoldilocksField,
     plonk::{
         circuit_builder::CircuitBuilder, circuit_data::CircuitData,
-        config::PoseidonGoldilocksConfig,
-        proof::ProofWithPublicInputs,
+        config::PoseidonGoldilocksConfig, proof::ProofWithPublicInputs,
     },
 };
 

--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
@@ -362,7 +362,7 @@ where
             let fields_for_param = typ.field_count() as usize;
             if vis == Visibility::Public {
                 self.asm_writer.register_public_inputs(
-                    &parameters[next_param_idx..next_param_idx+fields_for_param]
+                    &parameters[next_param_idx..next_param_idx + fields_for_param],
                 );
             }
             next_param_idx += fields_for_param;
@@ -707,7 +707,8 @@ where
 
                 let mut new_values = Vec::new();
                 for i in 0..p2targets.len() {
-                    new_values.push(P2Value::create_empty(&mut self.asm_writer, target_type.clone()));
+                    new_values
+                        .push(P2Value::create_empty(&mut self.asm_writer, target_type.clone()));
                     if i == num_index {
                         self.asm_writer.connect(p2value.get_target()?, new_values[i].get_target()?);
                     } else {

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -189,7 +189,7 @@ fn compile_programs(
                 package,
                 compile_options,
                 load_cached_program(package),
-		false,
+                false,
             )?;
             let program = nargo::ops::transform_program(program, compile_options.expression_width);
             save_program_to_file(

--- a/tooling/nargo_cli/src/cli/verify_cmd.rs
+++ b/tooling/nargo_cli/src/cli/verify_cmd.rs
@@ -85,12 +85,8 @@ fn verify_package(
     verifier_name: &str,
 ) -> Result<(), CliError> {
     let public_abi = compiled_program.abi.public_abi();
-    let (public_inputs_map, return_value) = read_inputs_from_file(
-        &package.root_dir,
-        verifier_name,
-        Format::Toml,
-        &public_abi,
-    )?;
+    let (public_inputs_map, return_value) =
+        read_inputs_from_file(&package.root_dir, verifier_name, Format::Toml, &public_abi)?;
 
     let public_inputs = public_abi.encode(&public_inputs_map, return_value)?;
 

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -373,11 +373,7 @@ impl Abi {
     pub fn public_abi(self) -> Abi {
         let parameters: Vec<_> =
             self.parameters.into_iter().filter(|param| param.is_public()).collect();
-        Abi {
-            parameters,
-            return_type: self.return_type,
-            error_types: self.error_types,
-        }
+        Abi { parameters, return_type: self.return_type, error_types: self.error_types }
     }
 }
 


### PR DESCRIPTION
Upstream consistently applies 'cargo fmt' to all their commits (they run 'cargo fmt --check' in their CI and expect empty output). This applies the 'cargo fmt' formatting fixes to our code as well.