### PR TITLE
test(unconstrained): add simple test

### DIFF
--- a/test_programs/execution_success/simple_unconstrained/Nargo.toml
+++ b/test_programs/execution_success/simple_unconstrained/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "simple_unconstrained"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/execution_success/simple_unconstrained/Prover.toml
+++ b/test_programs/execution_success/simple_unconstrained/Prover.toml
@@ -1,0 +1,2 @@
+sum_limit = "11"
+desired_sum = "55"

--- a/test_programs/execution_success/simple_unconstrained/src/main.nr
+++ b/test_programs/execution_success/simple_unconstrained/src/main.nr
@@ -1,0 +1,12 @@
+fn main(sum_limit: u64, desired_sum: pub u64) {
+    let actual_sum = sum(sum_limit);
+    assert(actual_sum == desired_sum);
+}
+
+unconstrained fn sum(sum_limit: u64) -> u64 {
+    let mut sum = 0;
+    for x in 1..sum_limit {
+        sum += x;
+    }
+    sum
+}


### PR DESCRIPTION
The purpose of this test is to show a minimal useful program that makes use of the `unconstrained` capabilities of Noir and to show that the `nargo` tool is capable of executing it and performing the associated assert.

Note that the `unconstrained` code is, unsurprisingly, not included in the constraint system, so it is not part of the ZK proof/verification. It is just a utility that allows programs to get around performance limitations of the arithmetic circuit paradigm. Modern zkVMs provide a way to include such code in the proof as well, but these are in even earlier stage of development at the moment.

To run test:

```
cargo test simple_unconstrained
```