### PR TITLE
feat(plonky2): updated error messages for unsupported array operation

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/plonky2_gen/mod.rs
@@ -681,7 +681,7 @@ impl Builder {
                 let num_index = match index {
                     Value::NumericConstant { constant, .. } => constant.to_u128() as usize,
                     _ => {
-                        let feature_name = format!("indexing array with an {:?}", index);
+                        let feature_name = format!("indexing array (get) with an {:?}", index);
                         return Err(Plonky2GenError::UnsupportedFeature { name: feature_name });
                     }
                 };
@@ -698,7 +698,7 @@ impl Builder {
                 let num_index = match index {
                     Value::NumericConstant { constant, .. } => constant.to_u128() as usize,
                     _ => {
-                        let feature_name = format!("indexing array with an {:?}", index);
+                        let feature_name = format!("indexing array (set) with an {:?}", index);
                         return Err(Plonky2GenError::UnsupportedFeature { name: feature_name });
                     }
                 };


### PR DESCRIPTION
The messages "unsupported indexing array with" updated to include in the message text whether it's doing an array get or an array set operation.