### PR TITLE
Nargo command for formal verifier tool

### DIFF
--- a/tooling/nargo_cli/src/cli/fv_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fv_cmd.rs
@@ -1,0 +1,24 @@
+use clap::Args;
+use noirc_frontend::graph::CrateName;
+
+use crate::errors::CliError;
+
+use super::NargoConfig;
+
+/// Perform formal verification on a program
+#[derive(Debug, Clone, Args)]
+#[clap(visible_alias = "fv")]
+pub(crate) struct FormalVerifyCommand {
+    /// The name of the package to formally verify
+    #[clap(long, conflicts_with = "workspace")]
+    package: Option<CrateName>,
+
+    /// formally verify all packages in the workspace
+    #[clap(long, conflicts_with = "package")]
+    workspace: bool,
+}
+
+pub(crate) fn run(args: FormalVerifyCommand, config: NargoConfig) -> Result<(), CliError> {
+    println!("Hello, this feature is not implemented yet");
+    Err(CliError::Generic("Not implemented yet".to_string()))
+}

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -23,6 +23,7 @@ mod prove_cmd;
 mod test_cmd;
 mod trace_cmd;
 mod verify_cmd;
+mod fv_cmd;
 
 const GIT_HASH: &str = env!("GIT_COMMIT");
 const IS_DIRTY: &str = env!("GIT_DIRTY");
@@ -75,6 +76,7 @@ enum NargoCommand {
     Lsp(lsp_cmd::LspCommand),
     #[command(hide = true)]
     Dap(dap_cmd::DapCommand),
+    FormalVerify(fv_cmd::FormalVerifyCommand),
 }
 
 #[cfg(not(feature = "codegen-docs"))]
@@ -110,6 +112,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
         NargoCommand::Lsp(args) => lsp_cmd::run(args, config),
         NargoCommand::Dap(args) => dap_cmd::run(args, config),
         NargoCommand::Fmt(args) => fmt_cmd::run(args, config),
+        NargoCommand::FormalVerify(args) => fv_cmd::run(args, config)
     }?;
 
     Ok(())


### PR DESCRIPTION
Added a command for the formal verification tool which is being worked on. Currently the command `nargo fv` prints a message for the user and returns a generic cli error.
