### PR TITLE
chore(fv): integrate annotation tokens into lexer

### DIFF
--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -1363,4 +1363,55 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_ensures_attribute() {
+        let input = r#"#[ensures(result == 4)]"#;
+        let expected_body = vec![
+            Token::Ident("result".to_string()),
+            Token::Equal,
+            Token::Int(4_i128.into()),
+            Token::EOF,
+        ];
+
+        let mut lexer = Lexer::new(input);
+        let token = lexer.next_token().unwrap();
+
+        assert_eq!(
+            token.token(),
+            &Token::Attribute(Attribute::Secondary(crate::token::SecondaryAttribute::Ensures(
+                Tokens(
+                    expected_body
+                        .iter()
+                        .map(|x| SpannedToken::new(x.clone(), Span::empty(0)))
+                        .collect()
+                )
+            )))
+        );
+    }
+    #[test]
+    fn test_requires_attribute() {
+        let input = r#"#[requires(x == 6)]"#;
+        let expected_body = vec![
+            Token::Ident("x".to_string()),
+            Token::Equal,
+            Token::Int(6_i128.into()),
+            Token::EOF,
+        ];
+
+        let mut lexer = Lexer::new(input);
+        let token = lexer.next_token().unwrap();
+
+        assert_eq!(
+            token.token(),
+            &Token::Attribute(Attribute::Secondary(crate::token::SecondaryAttribute::Requires(
+                Tokens(
+                    expected_body
+                        .iter()
+                        .map(|x| SpannedToken::new(x.clone(), Span::empty(0)))
+                        .collect()
+                )
+            )))
+        );
+    }
 }

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -10,6 +10,8 @@ use crate::{
     },
 };
 
+use super::Lexer;
+
 /// Represents a token in noir's grammar - a word, number,
 /// or symbol that can be used in noir's syntax. This is the
 /// smallest unit of grammar. A parser may (will) decide to parse
@@ -768,6 +770,20 @@ impl Attribute {
                 ))
             }
             ["varargs"] => Attribute::Secondary(SecondaryAttribute::Varargs),
+            ["ensures", body] => {
+                let (tokenized_body, errors) =  Lexer::lex(body);
+                if let Some(first_error) = errors.first() {
+                    return Err(first_error.clone());
+                }
+                Attribute::Secondary(SecondaryAttribute::Ensures(tokenized_body))
+            },
+            ["requires", body] => {
+                let (tokenized_body, errors) =  Lexer::lex(body);
+                if let Some(first_error) = errors.first() {
+                    return Err(first_error.clone());
+                }
+                Attribute::Secondary(SecondaryAttribute::Requires(tokenized_body))
+            },
             tokens => {
                 tokens.iter().try_for_each(|token| validate(token))?;
                 Attribute::Secondary(SecondaryAttribute::Custom(word.to_owned()))
@@ -865,7 +881,9 @@ pub enum SecondaryAttribute {
     Field(String),
     Custom(String),
     Abi(String),
-
+    // Formal verification attributes
+    Ensures(Tokens),
+    Requires(Tokens),
     /// A variable-argument comptime function.
     Varargs,
 }
@@ -893,6 +911,14 @@ impl fmt::Display for SecondaryAttribute {
             SecondaryAttribute::Field(ref k) => write!(f, "#[field({k})]"),
             SecondaryAttribute::Abi(ref k) => write!(f, "#[abi({k})]"),
             SecondaryAttribute::Varargs => write!(f, "#[varargs]"),
+            SecondaryAttribute::Ensures(ref k ) => {
+                write!(f, "#[ensures(")?;
+                k.0.iter().try_for_each(|x| x.0.contents.fmt(f))?;
+                write!(f, ")]")},
+            SecondaryAttribute::Requires(ref k ) => {
+                write!(f, "#[requires(")?;
+                k.0.iter().try_for_each(|x| x.0.contents.fmt(f))?;
+                write!(f, ")]")},
         }
     }
 }
@@ -922,6 +948,8 @@ impl AsRef<str> for SecondaryAttribute {
             SecondaryAttribute::ContractLibraryMethod => "",
             SecondaryAttribute::Export => "",
             SecondaryAttribute::Varargs => "",
+            SecondaryAttribute::Ensures(_) => "",
+            SecondaryAttribute::Requires(_) => "",
         }
     }
 }


### PR DESCRIPTION
Added tokens to the lexer to process our formal verification annotations, which follow the syntax of an attribute. Also added a unit test.
