### PR TITLE
feat(fv): add lexing for fv annotations

### DIFF
--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -303,9 +303,12 @@ impl<'a> Lexer<'a> {
         self.next_char();
 
         let contents_start = self.position + 1;
-
-        let word = self.eat_while(None, |ch| ch != ']');
-
+        let mut attribute_name = self.eat_while(None, |ch| ch != '(' && ch != ']');
+        if Self::is_fv_attribute(&attribute_name) {
+            return Ok(Self::into_fv_attribute_token(&attribute_name).unwrap().into_span(start, self.position))
+        } 
+        attribute_name.push_str(&self.eat_while(None, |ch| ch != ']'));
+        let word = attribute_name;
         let contents_end = self.position;
 
         if !self.peek_char_is(']') {
@@ -682,11 +685,23 @@ impl<'a> Lexer<'a> {
         c == '\t' || c == '\n' || c == '\r' || c == ' '
     }
 
+    fn is_fv_attribute(attribute_name: &str) -> bool {
+        attribute_name == "requires" || attribute_name == "ensures"
+    }
+
     /// Skips white space. They are not significant in the source language
     fn eat_whitespace(&mut self, initial_char: char) -> SpannedToken {
         let start = self.position;
         let whitespace = self.eat_while(initial_char.into(), Self::is_code_whitespace);
         SpannedToken::new(Token::Whitespace(whitespace), Span::inclusive(start, self.position))
+    }
+
+    fn into_fv_attribute_token(attribute_name :&str) -> Option<Token> {
+        match attribute_name {
+            "requires" => Some(Token::Requires),
+            "ensures" => Some(Token::Ensures),
+            _ => None,
+        }
     }
 }
 
@@ -1405,5 +1420,134 @@ mod tests {
                 assert!(token.is_err(), "Expected Err, found {token:?}");
             }
         }
+    }
+
+    fn assert_fv_attribute_lexes_to_tokens(attribute_text: &str, expected_tokens: Vec<Token>) {
+        let mut lexer = Lexer::new(attribute_text);
+
+        for token in expected_tokens.into_iter() {
+            let got = lexer.next_token().unwrap();
+            assert_eq!(got, token);
+        }
+    }
+
+    #[test]
+    fn ensures_attribute() {
+        let input = "#[ensures(result == 4)]\n";
+        let expected = vec![
+            Token::Ensures,
+            Token::LeftParen,
+            Token::Ident("result".to_string()),
+            Token::Equal,
+            Token::Int(4_i128.into()),
+            Token::RightParen,
+            Token::RightBracket,
+            Token::EOF,
+        ];
+
+        assert_fv_attribute_lexes_to_tokens(input, expected);
+    }
+
+    #[test]
+    fn multiple_attributes() {
+        let input = r#"#[ensures(x)]
+        #[ensures(result > 3)]
+        "#;
+        let expected = vec![
+            Token::Ensures,
+            Token::LeftParen,
+            Token::Ident("x".to_string()),
+            Token::RightParen,
+            Token::RightBracket,
+            Token::Ensures,
+            Token::LeftParen,
+            Token::Ident("result".to_string()),
+            Token::Greater,
+            Token::Int(3_i128.into()),
+            Token::RightParen,
+            Token::RightBracket,
+            Token::EOF,
+        ];
+
+        assert_fv_attribute_lexes_to_tokens(input, expected);
+    }
+    #[test]
+    fn requires_attribute() {
+        let input = "#[requires(x == 6)]\n";
+        let expected = vec![
+            Token::Requires,
+            Token::LeftParen,
+            Token::Ident("x".to_string()),
+            Token::Equal,
+            Token::Int(6_i128.into()),
+            Token::RightParen,
+            Token::RightBracket,
+            Token::EOF,
+        ];
+
+        assert_fv_attribute_lexes_to_tokens(input, expected);
+    }
+
+    #[test]
+    fn new_line_in_fv_attribute_body() {
+        let input = r#"#[requires(x
+        == 6)]
+        "#;
+        let expected = vec![
+            Token::Requires,
+            Token::LeftParen,
+            Token::Ident("x".to_string()), 
+            Token::Equal,
+            Token::Int(6_i128.into()),
+            Token::RightParen,
+            Token::RightBracket,
+            Token::EOF,
+        ];
+
+        assert_fv_attribute_lexes_to_tokens(input, expected);
+    }
+
+    #[test]
+    fn array_in_fv_attribute_body() {
+        let input = "#[ensures(result[0])]\n";
+        let expected = vec![
+            Token::Ensures,
+            Token::LeftParen,
+            Token::Ident("result".to_string()),
+            Token::LeftBracket,
+            Token::Int(0_i128.into()),
+            Token::RightBracket,
+            Token::RightParen,
+            Token::RightBracket,
+            Token::EOF,
+        ];
+
+        assert_fv_attribute_lexes_to_tokens(input, expected);
+    }
+
+    #[test]
+    fn multiple_attributes_2() {
+        let input = r#"#[requires(x < 2)]
+        #[ensures(result > 3)]
+        "#;
+        let expected = vec![
+            Token::Requires,
+            Token::LeftParen,
+            Token::Ident("x".to_string()),
+            Token::Less,
+            Token::Int(2_i128.into()),
+            Token::RightParen,
+            Token::RightBracket,
+            Token::Ensures,
+            Token::LeftParen,
+            Token::Ident("result".to_string()),
+            Token::Greater,
+            Token::Int(3_i128.into()),
+            Token::RightParen,
+            Token::RightBracket,
+            Token::EOF,
+        ];
+
+        assert_fv_attribute_lexes_to_tokens(input, expected);
     }
 }

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -102,6 +102,11 @@ pub enum BorrowedToken<'input> {
     DollarSign,
     /// =
     Assign,
+    /// #[requires
+    Requires,
+    /// #[ensures
+    Ensures,
+
     #[allow(clippy::upper_case_acronyms)]
     EOF,
 
@@ -217,6 +222,11 @@ pub enum Token {
     Assign,
     /// $
     DollarSign,
+    /// #[requires
+    Requires,
+    /// #[ensures
+    Ensures,
+
     #[allow(clippy::upper_case_acronyms)]
     EOF,
 
@@ -293,6 +303,8 @@ pub fn token_to_borrowed_token(token: &Token) -> BorrowedToken<'_> {
         Token::Invalid(c) => BorrowedToken::Invalid(*c),
         Token::Whitespace(ref s) => BorrowedToken::Whitespace(s),
         Token::UnquoteMarker(id) => BorrowedToken::UnquoteMarker(*id),
+        Token::Requires => BorrowedToken::Requires,
+        Token::Ensures => BorrowedToken::Ensures,
     }
 }
 
@@ -420,6 +432,8 @@ impl fmt::Display for Token {
             Token::Invalid(c) => write!(f, "{c}"),
             Token::Whitespace(ref s) => write!(f, "{s}"),
             Token::UnquoteMarker(_) => write!(f, "(UnquoteMarker)"),
+            Token::Requires => write!(f, "#[requires"),
+            Token::Ensures => write!(f, "#[ensures"),
         }
     }
 }


### PR DESCRIPTION
Made separate tokens for formal verification attributes because they need more complex lexing and parsing compared to the built-in attributes.

Also added lexing logic for them and added support for having new lines in the expression body of a formal verification attribute.

For more details please take a look at the added unit tests.

Some explanation for the code: I've added a flag in the Lexer struct which serves as an indicator if we are currently tokenizing a formal verification attribute or not. If we are tokenizing a formal verification attribute we must tokenize the new lines as the token EOL because they will serve us as an indicator where the attribute ends during the parsing process.

