### PR TITLE
feat(fv): add parsing for fv annotations

### DIFF
--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -3,6 +3,7 @@ use noirc_errors::{Position, Span, Spanned};
 use std::{fmt, iter::Map, vec::IntoIter};
 
 use crate::{
+    ast::Expression,
     lexer::errors::LexerErrorKind,
     node_interner::{
         ExprId, InternedExpressionKind, InternedPattern, InternedStatementKind,
@@ -650,7 +651,8 @@ impl fmt::Display for TestScope {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
+// #[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 // Attributes are special language markers in the target language
 // An example of one is `#[SHA256]` . Currently only Foreign attributes are supported
 // Calls to functions which have the foreign attribute are executed in the host language
@@ -659,11 +661,13 @@ pub struct Attributes {
     pub function: Option<FunctionAttribute>,
     // Each function can have many Secondary Attributes
     pub secondary: Vec<SecondaryAttribute>,
+    // Each function can have many Formal Verification Attributes
+    pub fv_attributes: Vec<FormalVerificationAttribute>,
 }
 
 impl Attributes {
     pub fn empty() -> Self {
-        Self { function: None, secondary: Vec::new() }
+        Self { function: None, secondary: Vec::new(), fv_attributes: Vec::new() }
     }
 
     /// Returns true if one of the secondary attributes is `contract_library_method`
@@ -991,6 +995,17 @@ impl CustomAtrribute {
             None
         }
     }
+}
+
+/// Formal verification attributes are used for nargo formal-verify.
+/// A function can have many formal verification attributes.
+/// They are not able to change the `FunctionKind` and thus do not have direct impact on the IR output.
+/// This enum will not be used as a Token, it will be used as a field in the structure Attributes which is a part of
+/// the structure FunctionDefinition   
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum FormalVerificationAttribute {
+    Ensures(Expression),
+    Requires(Expression),
 }
 
 impl AsRef<str> for FunctionAttribute {

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -651,7 +651,6 @@ impl fmt::Display for TestScope {
     }
 }
 
-// #[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
 #[derive(PartialEq, Eq, Debug, Clone)]
 // Attributes are special language markers in the target language
 // An example of one is `#[SHA256]` . Currently only Foreign attributes are supported
@@ -999,8 +998,8 @@ impl CustomAtrribute {
 
 /// Formal verification attributes are used for nargo formal-verify.
 /// A function can have many formal verification attributes.
-/// They are not able to change the `FunctionKind` and thus do not have direct impact on the IR output.
-/// This enum will not be used as a Token, it will be used as a field in the structure Attributes which is a part of
+/// They do not change the `FunctionKind` and thus do not have direct impact on the IR output.
+/// This enum is not used as a Token, it will be used as a field in the structure Attributes which is a part of
 /// the structure FunctionDefinition   
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum FormalVerificationAttribute {

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -69,7 +69,9 @@ pub enum ParserErrorReason {
     AssociatedTypesNotAllowedInPaths,
     #[error("Associated types are not allowed on a method call")]
     AssociatedTypesNotAllowedInMethodCalls,
-    #[error("Custom attributes are not allowed to be prefixed with a formal verification attribute")]
+    #[error(
+        "Custom attributes are not allowed to be prefixed with a formal verification attribute"
+    )]
     ReservedAttributeName,
 }
 

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -70,7 +70,7 @@ pub enum ParserErrorReason {
     #[error("Associated types are not allowed on a method call")]
     AssociatedTypesNotAllowedInMethodCalls,
     #[error("Custom attributes are not allowed to be prefixed with a formal verification attribute")]
-    InvalidCustomAttribute,
+    ReservedAttributeName,
 }
 
 /// Represents a parsing error, or a parsing error in the making.

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -69,6 +69,8 @@ pub enum ParserErrorReason {
     AssociatedTypesNotAllowedInPaths,
     #[error("Associated types are not allowed on a method call")]
     AssociatedTypesNotAllowedInMethodCalls,
+    #[error("Custom attributes are not allowed to be prefixed with a formal verification attribute")]
+    InvalidCustomAttribute,
 }
 
 /// Represents a parsing error, or a parsing error in the making.

--- a/compiler/noirc_frontend/src/parser/parser/attributes.rs
+++ b/compiler/noirc_frontend/src/parser/parser/attributes.rs
@@ -96,7 +96,7 @@ pub(super) fn validate_attributes(
                             secondary.push(attr)   
                         } else {
                             emit(ParserError::with_reason(
-                                ParserErrorReason::InvalidCustomAttribute,
+                                ParserErrorReason::ReservedAttributeName,
                                 span,
                             ));
                         }

--- a/compiler/noirc_frontend/src/parser/parser/attributes.rs
+++ b/compiler/noirc_frontend/src/parser/parser/attributes.rs
@@ -1,13 +1,13 @@
-use chumsky::Parser;
+use chumsky::{prelude::just, Parser};
 use noirc_errors::Span;
 
 use crate::{
     macros_api::SecondaryAttribute,
-    parser::{NoirParser, ParserError, ParserErrorReason},
-    token::{Attribute, Attributes, Token, TokenKind},
+    parser::{parenthesized, NoirParser, ParserError, ParserErrorReason},
+    token::{Attribute, Attributes, CustomAtrribute, FormalVerificationAttribute, Token, TokenKind},
 };
 
-use super::primitives::token_kind;
+use super::{expression, primitives::token_kind};
 
 fn attribute() -> impl NoirParser<Attribute> {
     token_kind(TokenKind::Attribute).map(|token| match token {
@@ -16,12 +16,62 @@ fn attribute() -> impl NoirParser<Attribute> {
     })
 }
 
+fn fv_attribute() -> impl NoirParser<FormalVerificationAttribute> {
+    token_kind(TokenKind::Token(Token::Ensures))
+        .or(token_kind(TokenKind::Token(Token::Requires)))
+        .then(
+            parenthesized(expression())
+        )
+        .then_ignore(just(Token::RightBracket))
+        .map(|(token, expr)| match token {
+            Token::Requires => FormalVerificationAttribute::Requires(expr),
+            Token::Ensures => FormalVerificationAttribute::Ensures(expr),
+            _ => unreachable!(
+                "Parser should have already errored due to token not being an attribute"
+            ),
+        })
+}
+
+/// Represents any attribute that is accepted by the language.
+/// This includes normal upstream attributes and formal verification attributes.
+pub(super) enum AnyAttribute { 
+    FvAttribute(FormalVerificationAttribute),
+    NormalAttribute(Attribute),
+}
+
+pub(super) fn all_attributes() -> impl NoirParser<Vec<AnyAttribute>> {
+    fv_attribute().map(|x| AnyAttribute::FvAttribute(x))
+    .or(attribute().map(|x| AnyAttribute::NormalAttribute(x)))
+    .repeated()
+}
+
+pub(super) fn split_attributes_in_two(
+    all_attributes: Vec<AnyAttribute>
+) -> (Vec<FormalVerificationAttribute>, Vec<Attribute>) {
+    let mut fv_attributes: Vec<FormalVerificationAttribute> = Vec::new();
+    let mut attributes: Vec<Attribute> = Vec::new();
+
+    all_attributes.into_iter().for_each(|attr| {
+        match attr {
+            AnyAttribute::FvAttribute(fv_attr) => fv_attributes.push(fv_attr),
+            AnyAttribute::NormalAttribute(normal_attr) => attributes.push(normal_attr),
+        }
+    });
+
+    (fv_attributes, attributes)
+}
+
 pub(super) fn attributes() -> impl NoirParser<Vec<Attribute>> {
     attribute().repeated()
 }
 
+fn is_valid_custom_attribute(custom_attr: CustomAtrribute) -> bool {
+    !(custom_attr.contents.starts_with("ensures") || custom_attr.contents.starts_with("requires"))
+}
+
 pub(super) fn validate_attributes(
     attributes: Vec<Attribute>,
+    fv_attributes: Vec<FormalVerificationAttribute>,
     span: Span,
     emit: &mut dyn FnMut(ParserError),
 ) -> Attributes {
@@ -39,11 +89,25 @@ pub(super) fn validate_attributes(
                 }
                 primary = Some(attr);
             }
-            Attribute::Secondary(attr) => secondary.push(attr),
+            Attribute::Secondary(attr) => {
+                match attr.clone() {
+                    SecondaryAttribute::Custom(custom_attr) => {
+                        if is_valid_custom_attribute(custom_attr) {
+                            secondary.push(attr)   
+                        } else {
+                            emit(ParserError::with_reason(
+                                ParserErrorReason::InvalidCustomAttribute,
+                                span,
+                            ));
+                        }
+                    },
+                    _ => secondary.push(attr)
+                }
+            },
         }
     }
 
-    Attributes { function: primary, secondary }
+    Attributes { function: primary, secondary, fv_attributes}
 }
 
 pub(super) fn validate_secondary_attributes(

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -176,7 +176,7 @@ fn function_parameters<'a>(allow_self: bool) -> impl NoirParser<Vec<Param>> + 'a
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::parser::parser::test_helpers::*;
+    use crate::{parser::parser::test_helpers::*, token::{FormalVerificationAttribute, SecondaryAttribute}};
 
     #[test]
     fn regression_skip_comment() {
@@ -284,36 +284,66 @@ mod test {
     }
 
     #[test]
-    fn parse_function_with_fv_attribute() {
+    fn formal_verification_requires_attribute_parses() {
         let src = r#"#[requires(x > 2)]
                     fn foo(x: i32) {}"#;
 
-        let res = parse_with(function_definition(false), src);
-        assert!(res.is_ok());
+        let function_definition = parse_with(function_definition(false), src).unwrap();
+        let parsed_attributes = &function_definition.attributes().fv_attributes;
+
+        assert_eq!(parsed_attributes.len(), 1, "Missmatching number of attributes.");
+        let FormalVerificationAttribute::Requires(_) = parsed_attributes[0] else {
+            panic!("Expected 'requires', but got {:?}.", parsed_attributes[0]);
+        };
     }
 
     #[test]
-    fn parse_function_with_fv_attributes() {
+    fn formal_verification_both_attributes_parse() {
         let src = r#"#[requires(x > 2)]
                     #[ensures(result < 8)]
                     fn foo(x: i32) {}"#;
-        let res = parse_with(function_definition(false), src);
-        assert!(res.is_ok());
+        
+        let function_definition = parse_with(function_definition(false), src).unwrap();
+        let parsed_attributes = &function_definition.attributes().fv_attributes;
+
+        assert_eq!(parsed_attributes.len(), 2, "Missmatching number of attributes.");
+        let FormalVerificationAttribute::Requires(_) = parsed_attributes[0] else {
+            panic!("Expected 'requires', but got {:?}.", parsed_attributes[0]);
+        };
+        let FormalVerificationAttribute::Ensures(_) = parsed_attributes[1] else {
+            panic!("Expected 'ensures', but got {:?}.", parsed_attributes[1]);
+        };
     }
 
     #[test]
-    fn parse_function_with_many_attributes() {
+    fn formal_verification_attributes_cooperate() {
         let src = r#"#[requires(x > 2)]
                     #[deprecated]
                     #[ensures(result < 8)]
                     #[requires(x < 5)]
                     fn foo(x: i32) {}"#;
-        let res = parse_with(function_definition(false), src);
-        assert!(res.is_ok());
+        let function_definition = parse_with(function_definition(false), src).unwrap();
+        let parsed_fv_attributes = &function_definition.attributes().fv_attributes;
+        let parsed_attributes = &function_definition.attributes().secondary;
+
+        assert_eq!(parsed_fv_attributes.len(), 3, "Expected 3 formal verification attributes.");
+        assert_eq!(parsed_attributes.len(), 1, "Expected 1 secondary attributes.");
+        let FormalVerificationAttribute::Requires(_) = parsed_fv_attributes[0] else {
+            panic!("Expected 'requires', but got {:?}.", parsed_fv_attributes[0]);
+        };
+        let SecondaryAttribute::Deprecated(_) = parsed_attributes[0] else {
+            panic!("Expected 'deprecated', but got {:?}.", parsed_attributes[0]);
+        };
+        let FormalVerificationAttribute::Ensures(_) = parsed_fv_attributes[1] else {
+            panic!("Expected 'requires', but got {:?}.", parsed_fv_attributes[1]);
+        };
+        let FormalVerificationAttribute::Requires(_) = parsed_fv_attributes[2] else {
+            panic!("Expected 'requires', but got {:?}.", parsed_fv_attributes[2]);
+        };
     }
     
     #[test]
-    fn fail_parse_function_with_fv_attribute() {
+    fn formal_verification_wrong_attribute_defs() {
         parse_all_failing(
             function_definition(false),
             vec![

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -176,7 +176,10 @@ fn function_parameters<'a>(allow_self: bool) -> impl NoirParser<Vec<Param>> + 'a
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{parser::parser::test_helpers::*, token::{FormalVerificationAttribute, SecondaryAttribute}};
+    use crate::{
+        parser::parser::test_helpers::*,
+        token::{FormalVerificationAttribute, SecondaryAttribute},
+    };
 
     #[test]
     fn regression_skip_comment() {
@@ -302,7 +305,7 @@ mod test {
         let src = r#"#[requires(x > 2)]
                     #[ensures(result < 8)]
                     fn foo(x: i32) {}"#;
-        
+
         let function_definition = parse_with(function_definition(false), src).unwrap();
         let parsed_attributes = &function_definition.attributes().fv_attributes;
 
@@ -322,26 +325,30 @@ mod test {
                     #[ensures(result < 8)]
                     #[requires(x < 5)]
                     fn foo(x: i32) {}"#;
+
         let function_definition = parse_with(function_definition(false), src).unwrap();
         let parsed_fv_attributes = &function_definition.attributes().fv_attributes;
         let parsed_attributes = &function_definition.attributes().secondary;
 
+        // Check that the formal verification attributes are parsed correctly.
         assert_eq!(parsed_fv_attributes.len(), 3, "Expected 3 formal verification attributes.");
-        assert_eq!(parsed_attributes.len(), 1, "Expected 1 secondary attributes.");
         let FormalVerificationAttribute::Requires(_) = parsed_fv_attributes[0] else {
             panic!("Expected 'requires', but got {:?}.", parsed_fv_attributes[0]);
         };
-        let SecondaryAttribute::Deprecated(_) = parsed_attributes[0] else {
-            panic!("Expected 'deprecated', but got {:?}.", parsed_attributes[0]);
-        };
         let FormalVerificationAttribute::Ensures(_) = parsed_fv_attributes[1] else {
-            panic!("Expected 'requires', but got {:?}.", parsed_fv_attributes[1]);
+            panic!("Expected 'ensures', but got {:?}.", parsed_fv_attributes[1]);
         };
         let FormalVerificationAttribute::Requires(_) = parsed_fv_attributes[2] else {
             panic!("Expected 'requires', but got {:?}.", parsed_fv_attributes[2]);
         };
+
+        // Check that the other attributes are not botched by this.
+        assert_eq!(parsed_attributes.len(), 1, "Expected 1 secondary attributes.");
+        let SecondaryAttribute::Deprecated(_) = parsed_attributes[0] else {
+            panic!("Expected 'deprecated', but got {:?}.", parsed_attributes[0]);
+        };
     }
-    
+
     #[test]
     fn formal_verification_wrong_attribute_defs() {
         parse_all_failing(
@@ -357,5 +364,5 @@ mod test {
                 "#[ensures(result > 4)x] fn foo(x: i32) {}",
             ],
         );
-    }    
+    }
 }


### PR DESCRIPTION
This commit adds the parsing of formal verification attributes and their attachment to `FunctionDefinition` which is a structure and part of the AST which the Noir parser generates.

In this commit we also define a limit for the custom attributes. Their content body can not have formal verification attribute as a prefix.

Taking a look at the added unit tests may help with understanding the newly added feature.