### PR TITLE
feat(fv): add semantic analysis for fv attributes

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -197,7 +197,7 @@ impl<'context> Elaborator<'context> {
 
         let mut function = NoirFunction { kind, def };
         self.define_function_meta(&mut function, func_id, Some(trait_id));
-        self.elaborate_function(func_id);
+        self.elaborate_function(func_id, Some(function.attributes()));
         let _ = self.scopes.end_function();
         // Don't check the scope tree for unused variables, they can't be used in a declaration anyway.
         self.generics.truncate(old_generic_count);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -178,7 +178,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             None => {
                 if matches!(&meta.function_body, FunctionBody::Unresolved(..)) {
                     self.elaborate_in_function(None, |elaborator| {
-                        elaborator.elaborate_function(function);
+                        elaborator.elaborate_function(function, None);
                     });
 
                     self.get_function_body(function, location)

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -168,6 +168,9 @@ pub struct FuncMeta {
 
     /// Custom attributes attached to this function.
     pub custom_attributes: Vec<CustomAttribute>,
+
+    /// Formal verification attributes attached to this function
+    pub formal_verification_attributes: Vec<ResolvedFvAttribute>,
 }
 
 #[derive(Debug, Clone)]
@@ -175,6 +178,12 @@ pub enum FunctionBody {
     Unresolved(FunctionKind, BlockExpression, Span),
     Resolving,
     Resolved,
+}
+
+#[derive(Debug, Clone)]
+pub enum ResolvedFvAttribute {
+    Ensures(ExprId),
+    Requires(ExprId),
 }
 
 impl FuncMeta {

--- a/test_programs/compile_failure/fv_attribute_name_resolution_1/Nargo.toml
+++ b/test_programs/compile_failure/fv_attribute_name_resolution_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/fv_attribute_name_resolution_1/src/main.nr
+++ b/test_programs/compile_failure/fv_attribute_name_resolution_1/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[requires(y > 5)]
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/compile_failure/fv_attribute_name_resolution_2/Nargo.toml
+++ b/test_programs/compile_failure/fv_attribute_name_resolution_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/fv_attribute_name_resolution_2/src/main.nr
+++ b/test_programs/compile_failure/fv_attribute_name_resolution_2/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[requires(result > 5)]  // result can be only used in the ensures attribute
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/compile_failure/fv_attribute_name_resolution_3/Nargo.toml
+++ b/test_programs/compile_failure/fv_attribute_name_resolution_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/fv_attribute_name_resolution_3/src/main.nr
+++ b/test_programs/compile_failure/fv_attribute_name_resolution_3/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[ensures(result > y)]
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/compile_failure/fv_attribute_type_check_1/Nargo.toml
+++ b/test_programs/compile_failure/fv_attribute_type_check_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/fv_attribute_type_check_1/src/main.nr
+++ b/test_programs/compile_failure/fv_attribute_type_check_1/src/main.nr
@@ -1,0 +1,9 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[requires(x)]
+fn foo(x: Field) -> Field {
+  x + x
+}
+

--- a/test_programs/compile_failure/fv_attribute_type_check_2/Nargo.toml
+++ b/test_programs/compile_failure/fv_attribute_type_check_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/fv_attribute_type_check_2/src/main.nr
+++ b/test_programs/compile_failure/fv_attribute_type_check_2/src/main.nr
@@ -1,0 +1,9 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[ensures(result)]
+fn foo(x: Field) -> Field {
+  x + x
+}
+

--- a/test_programs/compile_failure/fv_attribute_type_check_3/Nargo.toml
+++ b/test_programs/compile_failure/fv_attribute_type_check_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/fv_attribute_type_check_3/src/main.nr
+++ b/test_programs/compile_failure/fv_attribute_type_check_3/src/main.nr
@@ -1,0 +1,9 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[requires(5)]
+fn foo(x: Field) -> Field {
+  x + x
+}
+

--- a/test_programs/compile_success_empty/fv_attribute_name_resolution_1/Nargo.toml
+++ b/test_programs/compile_success_empty/fv_attribute_name_resolution_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/fv_attribute_name_resolution_1/src/main.nr
+++ b/test_programs/compile_success_empty/fv_attribute_name_resolution_1/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {}
+
+#[requires(x as u32 > 5)] // as u32 because fields can not be compared
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/compile_success_empty/fv_attribute_name_resolution_2/Nargo.toml
+++ b/test_programs/compile_success_empty/fv_attribute_name_resolution_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/fv_attribute_name_resolution_2/src/main.nr
+++ b/test_programs/compile_success_empty/fv_attribute_name_resolution_2/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {}
+
+#[ensures(result as u32 > 5)]  // result can be only used in the ensures attribute
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/compile_success_empty/fv_attribute_name_resolution_3/Nargo.toml
+++ b/test_programs/compile_success_empty/fv_attribute_name_resolution_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/fv_attribute_name_resolution_3/src/main.nr
+++ b/test_programs/compile_success_empty/fv_attribute_name_resolution_3/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {}
+
+#[ensures(result == x + x)]
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/compile_success_empty/fv_attribute_type_check_1/Nargo.toml
+++ b/test_programs/compile_success_empty/fv_attribute_type_check_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/fv_attribute_type_check_1/src/main.nr
+++ b/test_programs/compile_success_empty/fv_attribute_type_check_1/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[requires(x)]
+fn foo(x: bool) -> Field {
+  5
+}
+

--- a/test_programs/compile_success_empty/fv_attribute_type_check_2/Nargo.toml
+++ b/test_programs/compile_success_empty/fv_attribute_type_check_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/fv_attribute_type_check_2/src/main.nr
+++ b/test_programs/compile_success_empty/fv_attribute_type_check_2/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[ensures(result)]
+fn foo() -> bool {
+  true
+}
+

--- a/test_programs/compile_success_empty/fv_attribute_type_check_3/Nargo.toml
+++ b/test_programs/compile_success_empty/fv_attribute_type_check_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/fv_attribute_type_check_3/src/main.nr
+++ b/test_programs/compile_success_empty/fv_attribute_type_check_3/src/main.nr
@@ -1,0 +1,5 @@
+fn main() {}
+
+#[requires(5 > 5)]
+fn foo() {}
+


### PR DESCRIPTION
Added name resolution and type checking for the expression bodies of the formal verification attributes. This means that functions in HIR now have resolved formal verification attributes attached to them.

Added tests which showcase the newly added functionality.
