### PR TITLE
feat(fv): connect `nargo formal-verify` to logic

### DIFF
--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -50,6 +50,8 @@ pub struct Context<'file_manager, 'parsed_files> {
     pub parsed_files: Cow<'parsed_files, ParsedFiles>,
 
     pub package_build_path: PathBuf,
+
+    pub perform_formal_verification: bool,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -70,6 +72,7 @@ impl Context<'_, '_> {
             debug_instrumenter: DebugInstrumenter::default(),
             parsed_files: Cow::Owned(parsed_files),
             package_build_path: PathBuf::default(),
+            perform_formal_verification: false,
         }
     }
 
@@ -86,6 +89,7 @@ impl Context<'_, '_> {
             debug_instrumenter: DebugInstrumenter::default(),
             parsed_files: Cow::Borrowed(parsed_files),
             package_build_path: PathBuf::default(),
+            perform_formal_verification: false,
         }
     }
 

--- a/tooling/nargo_cli/src/cli/fv_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fv_cmd.rs
@@ -1,5 +1,13 @@
 use clap::Args;
-use noirc_frontend::graph::CrateName;
+use nargo::{
+    insert_all_files_for_workspace_into_file_manager, ops::report_errors, parse_all,
+    prepare_package,
+};
+use nargo_toml::{get_package_manifest, resolve_workspace_from_toml, PackageSelection};
+use noirc_driver::{
+    file_manager_with_stdlib, link_to_debug_crate, CompileOptions, NOIR_ARTIFACT_VERSION_STRING,
+};
+use noirc_frontend::{debug::DebugInstrumenter, graph::CrateName};
 
 use crate::errors::CliError;
 
@@ -13,12 +21,56 @@ pub(crate) struct FormalVerifyCommand {
     #[clap(long, conflicts_with = "workspace")]
     package: Option<CrateName>,
 
-    /// formally verify all packages in the workspace
+    /// Formally verify all packages in the workspace
     #[clap(long, conflicts_with = "package")]
     workspace: bool,
+
+    // This is necessary for compile functions
+    #[clap(flatten)]
+    compile_options: CompileOptions,
 }
 
 pub(crate) fn run(args: FormalVerifyCommand, config: NargoConfig) -> Result<(), CliError> {
-    println!("Hello, this feature is not implemented yet");
-    Err(CliError::Generic("Not implemented yet".to_string()))
+    let toml_path = get_package_manifest(&config.program_dir)?;
+    let default_selection =
+        if args.workspace { PackageSelection::All } else { PackageSelection::DefaultOrAll };
+    let selection = args.package.map_or(default_selection, PackageSelection::Selected);
+    let workspace = resolve_workspace_from_toml(
+        &toml_path,
+        selection,
+        Some(NOIR_ARTIFACT_VERSION_STRING.to_string()),
+    )?;
+
+    let mut workspace_file_manager = file_manager_with_stdlib(&workspace.root_dir);
+    insert_all_files_for_workspace_into_file_manager(&workspace, &mut workspace_file_manager);
+    let parsed_files = parse_all(&workspace_file_manager);
+
+    let binary_packages = workspace.into_iter().filter(|package| package.is_binary());
+    for package in binary_packages {
+        let (mut context, crate_id) =
+            prepare_package(&workspace_file_manager, &parsed_files, package);
+        link_to_debug_crate(&mut context, crate_id);
+        context.debug_instrumenter = DebugInstrumenter::default();
+        context.package_build_path = workspace.package_build_path(package);
+        // Note: This is the only important line in this function. Everything else is equivalent to the compile command.
+        // (Except saving the result in a file.)
+        context.perform_formal_verification = true;
+
+        let formal_verification_result = noirc_driver::compile_main(
+            &mut context,
+            crate_id,
+            &args.compile_options,
+            None,
+            false,
+        );
+
+        report_errors(
+            formal_verification_result,
+            &workspace_file_manager,
+            args.compile_options.deny_warnings,
+            true, // We don't want to report compile related warnings
+        )?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Now if you run `nargo formal-verify` in a Noir workspace it will parse and do semantic analysis on all formal verification annotations. This happens only if the code can be compiled. Otherwise, it will throw compiler errors.

`nargo formal-verify` won't produce an output if the formal verification was successful.
