### PR TITLE
feat(shell.nix): Add llvm-tools binaries to path and add rustfilt package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
             rustfmt
             llvm-tools
           ];
-        devShells.default = import ./shell.nix {inherit pkgs self';};
+        devShells.default = import ./shell.nix {inherit pkgs self' inputs';};
       };
     };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 {
   pkgs,
   self',
+  inputs',
   ...
 }: let
   inherit (pkgs) lib stdenv mkShell;
@@ -12,9 +13,13 @@ in
       [
         pkgs.alejandra
         self'.legacyPackages.rustToolchain
+        pkgs.rustfilt
       ]
       ++ lib.optionals stdenv.isDarwin [
         pkgs.libiconv
         frameworks.CoreServices
       ];
+    shellHook = ''
+      export PATH="${inputs'.fenix.packages.latest.llvm-tools}/lib/rustlib/x86_64-unknown-linux-gnu/bin:$PATH"
+    '';
   }


### PR DESCRIPTION
Needed for @nickysn's work on tests and code coverage.

The `x86_64-unknown-linux-gnu` part from PATH will need to be changed for other architectures, but I don't know of any easy way to figure out this string, so for now I'll leave it as-is and will update in the future, if/when needed (any implementation > no implementation).