### PR TITLE
build(nix-shell): Nixify Venir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,7 +2854,6 @@ dependencies = [
  "tower",
  "tracing-appender",
  "tracing-subscriber",
- "vir",
 ]
 
 [[package]]

--- a/derivation.nix
+++ b/derivation.nix
@@ -1,0 +1,49 @@
+# stanm: The single purpose of this script is to bootstrap rustup.
+{
+  pkgs,
+  self',
+  venir-toolchain,
+  ...
+}: let
+  inherit (pkgs) lib rustPlatform fetchFromGitHub;
+
+  customRustPlatform = pkgs.makeRustPlatform {
+    cargo = venir-toolchain;
+    rustc = venir-toolchain;
+  };
+in
+  customRustPlatform.buildRustPackage rec {
+    pname = "Venir";
+    name = pname;
+    binaryName = "noir_verifier";
+    version = "0.1.0";
+
+    RUSTC_BOOTSTRAP = 1;
+
+    doCheck = false;
+
+    src = fetchFromGitHub {
+      owner = "blocksense-network";
+      repo = "Venir";
+      hash = "sha256-/owacNYeiETVR7uVtwO+cS3+Cu7+YvKURIoIB4t2eKI=";
+      rev = "d5a1ae9c44d0c94a729bda639177e0a386da7e34";
+    };
+
+    cargoLock = {
+      # Getting the lockfile for a remote project with git dependencies in it is a notoriously difficult problem
+      # For now this will work, more idiomatic solutions however are in the works
+      lockFile = "${src}/Cargo.lock";
+
+      outputHashes = {
+        "getopts-0.2.21" = "sha256-r9CiPUSsjhThK6RG3AvhfTjaXMex/VV7CbdLQIDMdTk=";
+        "smt2parser-0.6.1" = "sha256-AKBq8Ph8D2ucyaBpmDtOypwYie12xVl4gLRxttv5Ods=";
+        "air-0.1.0" = "sha256-+8rK0Liv+62jVT3BNp1g/9jdsc0OpmV7hpcITMn5mRY=";
+      };
+    };
+
+    cargoHash = "sha256-ER9SPWnoSmDln/8nTMeojSYvK4HxQzFCR6C6nSxFpOM=";
+
+    preFixup = ''
+      patchelf --set-rpath "${venir-toolchain}/lib" "$out/bin/${binaryName}"
+    '';
+  }

--- a/derivation.nix
+++ b/derivation.nix
@@ -15,7 +15,7 @@ in
   customRustPlatform.buildRustPackage rec {
     pname = "Venir";
     name = pname;
-    binaryName = "noir_verifier";
+    binaryName = "venir";
     version = "0.1.0";
 
     RUSTC_BOOTSTRAP = 1;
@@ -25,8 +25,8 @@ in
     src = fetchFromGitHub {
       owner = "blocksense-network";
       repo = "Venir";
-      hash = "sha256-/owacNYeiETVR7uVtwO+cS3+Cu7+YvKURIoIB4t2eKI=";
-      rev = "d5a1ae9c44d0c94a729bda639177e0a386da7e34";
+      hash = "sha256-SKhqc4fNT128KnLmoyL0xo8vrCGtAZanG3XcMDW8SjM";
+      rev = "1fc4019f06bc8bdf4bba084cc4a404bb686a9c07";
     };
 
     cargoLock = {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,18 @@
     };
   };
 
-  outputs = inputs @ {flake-parts, ...}:
+  outputs = inputs @ {
+    nixpkgs,
+    flake-parts,
+    fenix,
+    ...
+  }: let
+    system = "x86_64-linux";
+    venir-toolchain = fenix.packages.${system}.fromToolchainFile {
+      file = ./venir-toolchain.toml;
+      sha256 = "sha256-e4mlaJehWBymYxJGgnbuCObVlqMlQSilZ8FljG9zPHY=";
+    };
+  in
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
       perSystem = {
@@ -27,7 +38,7 @@
             rustc
             rustfmt
           ];
-        devShells.default = import ./shell.nix {inherit pkgs self';};
+        devShells.default = import ./shell.nix {inherit pkgs self' venir-toolchain;};
       };
     };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,16 +2,20 @@
 {
   pkgs,
   self',
+  venir-toolchain,
   ...
 }: let
   inherit (pkgs) lib stdenv mkShell;
   inherit (pkgs.darwin.apple_sdk) frameworks;
+  venir = import ./derivation.nix {inherit pkgs self' venir-toolchain;};
 in
   mkShell {
     packages =
       [
         pkgs.alejandra
+        venir
         self'.legacyPackages.rustToolchain
+        # pkgs.rustfilt
       ]
       ++ lib.optionals stdenv.isDarwin [
         pkgs.libiconv

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ in
     packages =
       [
         pkgs.alejandra
+        pkgs.z3_4_12
         venir
         self'.legacyPackages.rustToolchain
         # pkgs.rustfilt
@@ -21,4 +22,7 @@ in
         pkgs.libiconv
         frameworks.CoreServices
       ];
+    shellHook = ''
+      export VERUS_Z3_PATH=$(which z3)
+    '';
   }

--- a/venir-toolchain.toml
+++ b/venir-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.76.0"
+# channel = "nightly-2023-09-29" # (not officially supported)
+components = [ "rustc", "rust-analyzer", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools", "llvm"]


### PR DESCRIPTION
Nix develop now packages the Venir project and adds it to $PATH.
This change should make it more seamless to the user that the Noir formal verification depends on the external binary Venir.
