### PR TITLE
feat(nix): Nixify Verus std

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,7 +71,8 @@
       "inputs": {
         "fenix": "fenix",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "verus-lib": "verus-lib"
       }
     },
     "rust-analyzer-src": {
@@ -88,6 +89,22 @@
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "verus-lib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731935688,
+        "narHash": "sha256-neRsUNdi0xThO4RSAPUDPZZRwh00JAy4bw0eSKcka68=",
+        "owner": "Aristotelis2002",
+        "repo": "verus-lib",
+        "rev": "3a53f3e311eff68776a583dbf46759857712c182",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Aristotelis2002",
+        "repo": "verus-lib",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,12 +6,18 @@
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    verus-lib = {
+      url = "github:Aristotelis2002/verus-lib";
+      flake = false;
+    };
   };
 
   outputs = inputs @ {
     nixpkgs,
     flake-parts,
     fenix,
+    verus-lib,
     ...
   }: let
     system = "x86_64-linux";
@@ -38,7 +44,7 @@
             rustc
             rustfmt
           ];
-        devShells.default = import ./shell.nix {inherit pkgs self' venir-toolchain;};
+        devShells.default = import ./shell.nix {inherit pkgs self' venir-toolchain verus-lib;};
       };
     };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,11 +3,13 @@
   pkgs,
   self',
   venir-toolchain,
+  verus-lib,
   ...
 }: let
   inherit (pkgs) lib stdenv mkShell;
   inherit (pkgs.darwin.apple_sdk) frameworks;
   venir = import ./derivation.nix {inherit pkgs self' venir-toolchain;};
+  verus-std = import ./verusStd.nix {inherit pkgs self' venir-toolchain verus-lib;};
 in
   mkShell {
     packages =
@@ -16,6 +18,7 @@ in
         pkgs.z3_4_12
         venir
         self'.legacyPackages.rustToolchain
+        verus-std
         # pkgs.rustfilt
       ]
       ++ lib.optionals stdenv.isDarwin [
@@ -24,6 +27,6 @@ in
       ];
     shellHook = ''
       export VERUS_Z3_PATH=$(which z3)
-      #export VARGO_TARGET_DIR="../verus-lib/source/target-verus/debug"
+      export VARGO_TARGET_DIR="${verus-std}/lib/";
     '';
   }

--- a/verusStd.nix
+++ b/verusStd.nix
@@ -1,0 +1,90 @@
+{
+  pkgs,
+  venir-toolchain,
+  ...
+}: let
+  inherit (pkgs) fetchFromGitHub rustup;
+
+  customRustPlatform = pkgs.makeRustPlatform {
+    cargo = venir-toolchain;
+    rustc = venir-toolchain;
+  };
+in
+  customRustPlatform.buildRustPackage rec {
+    pname = "verus-lib";
+    name = pname;
+    version = "0.1.0";
+
+    nativeBuildInputs = [rustup];
+
+    z3_path = pkgs.z3_4_12;
+    VERUS_Z3_PATH = "${z3_path}/bin/z3";
+    RUSTC_BOOTSTRAP = 1;
+    VERUS_IN_VARGO = 1;
+    RUSTFLAGS = "--cfg proc_macro_span --cfg verus_keep_ghost --cfg span_locations";
+
+    # This disables the cargo tests.
+    # Some transitive dependency tests fail, not sure why. This disables them
+
+    # (The formal verification tests however pass, which are the ones we care about)
+    doCheck = false;
+
+    der = fetchFromGitHub {
+      owner = "Aristotelis2002";
+      repo = "verus-lib";
+      hash = "sha256-DziMs2hjVZJ/5lsoRAVcmbPwEbW7heyad6qq/Se+QVE=";
+      rev = "0a130e8bdce2b51d5af7f3c4c3ecbf01ee9e001c";
+    };
+
+    src = "${der}";
+
+    cargoLock = {
+      # Getting the lockfile for a remote project with git dependencies in it is a notoriously difficult problem
+      # For now this will work, more idiomatic solutions however are in the works
+      lockFile = "${src}/source/Cargo.lock";
+
+      outputHashes = {
+        "getopts-0.2.21" = "sha256-r9CiPUSsjhThK6RG3AvhfTjaXMex/VV7CbdLQIDMdTk";
+        "smt2parser-0.6.1" = "sha256-AKBq8Ph8D2ucyaBpmDtOypwYie12xVl4gLRxttv5Ods=";
+      };
+    };
+
+    postUnpack = ''
+
+      # buildRustPackage is confused as to the correct location of the source dir
+      # Project structure is a bit odd. This is an acceptable workaround.
+      # (Maybe just move instead of copying)
+      cp -r ./source/source/* ./source
+      cp -r ./source/dependencies ./dependencies
+      cp -r ./source/tools ./tools
+
+      # We need to delete the project's .toml file, so as to stop rustup from trying
+      # to download the needed toolchain from the internet
+      # NOTE: The nix env is sandboxed, it doesn't have access to the internet
+      rm ./source/rust-toolchain.toml
+    '';
+
+    buildPhase = ''
+      # Set up RUSTUP_HOME and CARGO_HOME to use writable directories
+      export RUSTUP_HOME=$out/.rustup
+      export CARGO_HOME=$out/.cargo
+
+      mkdir -p $RUSTUP_HOME $CARGO_HOME
+
+      # The name for our toolchain is very deliberate. If we were to change the rust versin,
+      # we would most likely need change this also
+      # TODO: I am very happy for suggestions how to circumvent this naming
+      # (We can always change the source code for vstd in our fork of Verus)
+      rustup toolchain link 1.76.0-x86_64-known-linux-gnu ${venir-toolchain.out}
+      rustup default 1.76.0-x86_64-known-linux-gnu
+
+      # Build the project
+      cargo build
+    '';
+
+    installPhase = ''
+      mkdir -p $out/lib
+      cargo run -p vstd_build -- ./target/debug/
+      cp ./target/debug/vstd.vir $out/lib/
+    '';
+  }


### PR DESCRIPTION
With this commit now we have nixified Verus std which means when we run direnv allow we will have vstd.vir locally available. This file contains the Verus standard library. Without it we wouldn't be able to formally verify arrays.