### PR TITLE
feat(fv): Ignore unconstrained print

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -9,7 +9,7 @@ use noirc_frontend::monomorphization::ast::InlineType;
 use crate::ssa::ir::{
     basic_block::BasicBlockId,
     function::{Function, FunctionId},
-    instruction::{Binary, BinaryOp, Instruction, FvInstruction, TerminatorInstruction},
+    instruction::{Binary, BinaryOp, FvInstruction, Instruction, TerminatorInstruction},
     types::Type,
     value::{Value, ValueId},
 };
@@ -179,7 +179,7 @@ impl FunctionBuilder {
 
             dfg.make_instruction_results_fv(id, ctrl_typevars, instruction.clone().result_type());
             dfg.fv_instructions.push(match self.fv_instruction {
-                FvBuilder::Ensures  => FvInstruction::Ensures(instruction),
+                FvBuilder::Ensures => FvInstruction::Ensures(instruction),
                 FvBuilder::Requires => FvInstruction::Requires(instruction),
                 FvBuilder::None => unreachable!(), // The if condition ensures this
             });

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -6,7 +6,8 @@ use super::{
     basic_block::{BasicBlock, BasicBlockId},
     function::FunctionId,
     instruction::{
-        Instruction, FvInstruction, InstructionId, InstructionResultType, Intrinsic, TerminatorInstruction,
+        FvInstruction, Instruction, InstructionId, InstructionResultType, Intrinsic,
+        TerminatorInstruction,
     },
     map::DenseMap,
     types::Type,
@@ -318,7 +319,7 @@ impl DataFlowGraph {
         if self.fv_instructions.len() > 0 {
             for id in (0..self.fv_instructions.len()).rev().map(|x| self.fv_start_id + x) {
                 let res = self.results.remove(&InstructionId::new(id)).unwrap();
-                self.results.insert(InstructionId::new(id+1), res);
+                self.results.insert(InstructionId::new(id + 1), res);
             }
             self.fv_start_id += 1;
         }
@@ -578,8 +579,7 @@ impl std::ops::Index<InstructionId> for DataFlowGraph {
                 FvInstruction::Ensures(i) => &i,
                 FvInstruction::Requires(i) => &i,
             }
-        }
-        else {
+        } else {
             &self.instructions[id]
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/ir/function_inserter.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function_inserter.rs
@@ -6,7 +6,7 @@ use super::{
     basic_block::BasicBlockId,
     dfg::{CallStack, InsertInstructionResult},
     function::Function,
-    instruction::{Instruction, FvInstruction, InstructionId},
+    instruction::{FvInstruction, Instruction, InstructionId},
     value::ValueId,
 };
 use fxhash::FxHashMap as HashMap;
@@ -106,14 +106,21 @@ impl<'f> FunctionInserter<'f> {
     }
 
     fn map_fv_instructions(&mut self) {
-        let newfv = self.function.dfg.fv_instructions.clone().iter().map(|fv| {
-            match fv {
-                FvInstruction::Requires(instr) =>
-                    FvInstruction::Requires(instr.clone().map_values(|v| self.resolve(v))),
-                FvInstruction::Ensures(instr) =>
-                    FvInstruction::Ensures(instr.clone().map_values(|v| self.resolve(v))),
-            }
-        }).collect();
+        let newfv = self
+            .function
+            .dfg
+            .fv_instructions
+            .clone()
+            .iter()
+            .map(|fv| match fv {
+                FvInstruction::Requires(instr) => {
+                    FvInstruction::Requires(instr.clone().map_values(|v| self.resolve(v)))
+                }
+                FvInstruction::Ensures(instr) => {
+                    FvInstruction::Ensures(instr.clone().map_values(|v| self.resolve(v)))
+                }
+            })
+            .collect();
         self.function.dfg.fv_instructions = newfv;
     }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -12,13 +12,16 @@ use super::{
     basic_block::BasicBlockId,
     dfg::DataFlowGraph,
     function::Function,
-    instruction::{ConstrainError, Instruction, FvInstruction, InstructionId, TerminatorInstruction},
+    instruction::{
+        ConstrainError, FvInstruction, Instruction, InstructionId, TerminatorInstruction,
+    },
     value::{Value, ValueId},
 };
 
 #[derive(PartialEq)]
 enum Attribute {
-    Requires, Ensures,
+    Requires,
+    Ensures,
 }
 
 impl Attribute {
@@ -48,20 +51,26 @@ fn display_fv_attribute(function: &Function, attribute: Attribute, f: &mut Forma
                 if attribute == Attribute::Ensures {
                     display_fv_instruction(function, id, instruction, f)?
                 }
-            },
+            }
             FvInstruction::Requires(instruction) => {
                 if attribute == Attribute::Requires {
                     display_fv_instruction(function, id, instruction, f)?
                 }
-            },
+            }
         }
     }
     writeln!(f, ")")
 }
 
-fn display_fv_instruction(function: &Function, id: usize, instruction: &Instruction, f: &mut Formatter) -> Result {
+fn display_fv_instruction(
+    function: &Function,
+    id: usize,
+    instruction: &Instruction,
+    f: &mut Formatter,
+) -> Result {
     write!(f, "    ")?;
-    let results = function.dfg.instruction_results(InstructionId::new(function.dfg.fv_start_id + id));
+    let results =
+        function.dfg.instruction_results(InstructionId::new(function.dfg.fv_start_id + id));
     if !results.is_empty() {
         write!(f, "{} = ", value_list(function, results))?;
     }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -115,7 +115,13 @@ impl<'a> FunctionContext<'a> {
         let mut builder = FunctionBuilder::new(function_name, function_id);
         builder.set_runtime(runtime);
         let definitions = HashMap::default();
-        let mut this = Self { definitions, builder, shared_context, loops: Vec::new(), return_value: Tree::empty() };
+        let mut this = Self {
+            definitions,
+            builder,
+            shared_context,
+            loops: Vec::new(),
+            return_value: Tree::empty(),
+        };
         this.add_parameters_to_scope(parameters);
         this
     }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -32,7 +32,7 @@ use std::{
     unreachable,
 };
 
-use self::ast::{ InlineType, FvExpression };
+use self::ast::{FvExpression, InlineType};
 use self::debug_types::DebugTypeTracker;
 use self::{
     ast::{Definition, FuncId, Function, LocalId, Program},
@@ -336,13 +336,12 @@ impl<'interner> Monomorphizer<'interner> {
 
         let parameters = self.parameters(&meta.parameters)?;
         let body = self.expr(body_expr_id)?;
-        let formal_verification_expressions = meta.formal_verification_attributes
+        let formal_verification_expressions = meta
+            .formal_verification_attributes
             .iter()
-            .map(|fv: &ResolvedFvAttribute| {
-                match *fv {
-                    ResolvedFvAttribute::Ensures(id)  => FvExpression::Ensures(self.expr(id).unwrap()),
-                    ResolvedFvAttribute::Requires(id) => FvExpression::Requires(self.expr(id).unwrap()),
-                }
+            .map(|fv: &ResolvedFvAttribute| match *fv {
+                ResolvedFvAttribute::Ensures(id) => FvExpression::Ensures(self.expr(id).unwrap()),
+                ResolvedFvAttribute::Requires(id) => FvExpression::Requires(self.expr(id).unwrap()),
             })
             .collect();
         let function = ast::Function {


### PR DESCRIPTION
Now we can formally verify code which has print functions in it.
Also run `cargo fmt`.