### PR TITLE
feat(fv): Change how we formally verify `ifs`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/attributes.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/attributes.rs
@@ -9,12 +9,12 @@ use crate::ssa::verus_vir_gen::{
     },
 };
 
-use super::{CurrentContext, DataFlowGraph, Function, FvInstruction, Id, Instruction};
+use super::{SSAContext, DataFlowGraph, Function, FvInstruction, Id, Instruction};
 
 fn func_attributes_to_vir_expr(
     attribute_instructions: Vec<(Id<Instruction>, Instruction)>,
     dfg: &DataFlowGraph,
-    current_context: &mut CurrentContext,
+    current_context: &mut SSAContext,
 ) -> Vec<Expr> {
     if let Some((last_instruction_id, last_instruction)) = attribute_instructions.last() {
         let mut vir_statements: Vec<Stmt> = Vec::new();
@@ -50,7 +50,7 @@ fn func_attributes_to_vir_expr(
 
 pub(crate) fn func_requires_to_vir_expr(
     func: &Function,
-    current_context: &mut CurrentContext,
+    current_context: &mut SSAContext,
 ) -> Exprs {
     let attr_instrs: Vec<(Id<Instruction>, Instruction)> = func
         .dfg
@@ -71,7 +71,7 @@ pub(crate) fn func_requires_to_vir_expr(
 
 pub(crate) fn func_ensures_to_vir_expr(
     func: &Function,
-    current_context: &mut CurrentContext,
+    current_context: &mut SSAContext,
 ) -> Exprs {
     let attr_instrs: Vec<(Id<Instruction>, Instruction)> = func
         .dfg

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/context.rs
@@ -78,7 +78,7 @@ impl ResultIdFixer {
 }
 
 
-pub(crate) struct CurrentContext<'a> {
+pub(crate) struct SSAContext<'a> {
     pub result_id_fixer: Option<&'a ResultIdFixer>,
     pub side_effects_condition: Option<ValueId>,
 }

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/context.rs
@@ -80,4 +80,5 @@ impl ResultIdFixer {
 
 pub(crate) struct CurrentContext<'a> {
     pub result_id_fixer: Option<&'a ResultIdFixer>,
+    pub side_effects_condition: Option<ValueId>,
 }

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
@@ -200,7 +200,7 @@ fn binary_instruction_to_expr(
     binary: &Binary,
     mode: Mode,
     dfg: &DataFlowGraph,
-    current_context: &mut CurrentContext,
+    current_context: &mut SSAContext,
 ) -> Expr {
     let Binary { lhs, rhs, operator } = binary;
     let lhs_expr = ssa_value_to_expr(lhs, dfg, current_context.result_id_fixer);
@@ -572,7 +572,7 @@ pub(crate) fn instruction_to_expr(
     instruction: &Instruction,
     mode: Mode,
     dfg: &DataFlowGraph,
-    current_context: &mut CurrentContext,
+    current_context: &mut SSAContext,
 ) -> Expr {
     match instruction {
         Instruction::Binary(binary) => {
@@ -693,7 +693,7 @@ fn is_instruction_call_to_print(instruction_id: &InstructionId, dfg: &DataFlowGr
 pub(crate) fn basic_block_to_exprx(
     basic_block_id: Id<BasicBlock>,
     dfg: &DataFlowGraph,
-    current_context: &mut CurrentContext,
+    current_context: &mut SSAContext,
 ) -> (ExprX, Typ) {
     let basic_block = dfg[basic_block_id].clone();
     let mut vir_statements: Vec<Stmt> = Vec::new();

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/patterns.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/patterns.rs
@@ -59,7 +59,7 @@ pub(crate) fn instruction_to_stmt(
     dfg: &DataFlowGraph,
     instruction_id: Id<Instruction>,
     mode: Mode,
-    current_context: &mut CurrentContext,
+    current_context: &mut SSAContext,
 ) -> Stmt {
     let instruction_span =
         build_span(&instruction_id, format!("Instruction({}) statement", instruction_id));

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/function.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/function.rs
@@ -96,7 +96,8 @@ pub(crate) fn build_funx(
 
     let ret = get_function_return_param(func)?;
     let result_id_fixer = ResultIdFixer::new(func, &ret).ok();
-    let mut current_context = CurrentContext { result_id_fixer: result_id_fixer.as_ref() };
+    let mut current_context =
+        CurrentContext { result_id_fixer: result_id_fixer.as_ref(), side_effects_condition: None };
 
     let funx: FunctionX = FunctionX {
         name: func_id_into_funx_name(func_id),

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/function.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/function.rs
@@ -12,7 +12,7 @@ use super::{
         exprs::basic_block_to_exprx,
         params::{get_function_params, get_function_return_param},
     },
-    func_id_into_funx_name, get_func_kind, BuildingKrateError, CurrentContext, Function,
+    func_id_into_funx_name, get_func_kind, BuildingKrateError, SSAContext, Function,
     FunctionId, ResultIdFixer, TerminatorInstruction, ValueId,
 };
 
@@ -77,7 +77,7 @@ fn build_default_funx_attrs(zero_args: bool) -> FunctionAttrs {
     })
 }
 
-fn func_body_to_vir_expr(func: &Function, current_context: &mut CurrentContext) -> Expr {
+fn func_body_to_vir_expr(func: &Function, current_context: &mut SSAContext) -> Expr {
     let (block_exprx, block_type) =
         basic_block_to_exprx(func.entry_block(), &func.dfg, current_context);
     SpannedTyped::new(
@@ -97,7 +97,7 @@ pub(crate) fn build_funx(
     let ret = get_function_return_param(func)?;
     let result_id_fixer = ResultIdFixer::new(func, &ret).ok();
     let mut current_context =
-        CurrentContext { result_id_fixer: result_id_fixer.as_ref(), side_effects_condition: None };
+        SSAContext { result_id_fixer: result_id_fixer.as_ref(), side_effects_condition: None };
 
     let funx: FunctionX = FunctionX {
         name: func_id_into_funx_name(func_id),

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/mod.rs
@@ -4,7 +4,7 @@ mod expr_to_vir;
 mod function;
 
 use acvm::{AcirField, FieldElement};
-use context::{CurrentContext, ResultIdFixer};
+use context::{SSAContext, ResultIdFixer};
 use function::build_funx;
 use num_bigint::{BigInt, BigUint};
 use std::sync::Arc;

--- a/test_programs/formal_verify_failure/if_overflow/Nargo.toml
+++ b/test_programs/formal_verify_failure/if_overflow/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "if_test_overflow"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/if_overflow/src/main.nr
+++ b/test_programs/formal_verify_failure/if_overflow/src/main.nr
@@ -1,0 +1,10 @@
+// This test is expected to fail
+#[requires(y != 255)]
+fn main(x: u8, y: u16) -> pub u8 {
+    if x as u16 < y {
+        x + 1
+    }
+    else {
+        0
+    }
+}

--- a/test_programs/formal_verify_success/if_overflow_1/Nargo.toml
+++ b/test_programs/formal_verify_success/if_overflow_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "if_test_overflow_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/if_overflow_1/src/main.nr
+++ b/test_programs/formal_verify_success/if_overflow_1/src/main.nr
@@ -1,0 +1,10 @@
+// Verification should pass because all overflows
+// are prevented by the if condition
+fn main(x: u8) -> pub u8 {
+    if x < 255 {
+        x + 1
+    }
+    else {
+        0
+    }
+}

--- a/test_programs/formal_verify_success/if_overflow_2/Nargo.toml
+++ b/test_programs/formal_verify_success/if_overflow_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "if_test_overflow_2"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/if_overflow_2/src/main.nr
+++ b/test_programs/formal_verify_success/if_overflow_2/src/main.nr
@@ -1,0 +1,14 @@
+// Verification should pass because all overflows
+// are prevented by the if condition.
+// We also expect the requires clause 
+// to work correctly and make the test
+// equivalent to if_test_overflow_1
+#[requires(y == 255)]
+fn main(x: u8, y: u8) -> pub u8 {
+    if x < y {
+        x + 1
+    }
+    else {
+        0
+    }
+}

--- a/test_programs/formal_verify_success/if_overflow_complex/Nargo.toml
+++ b/test_programs/formal_verify_success/if_overflow_complex/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "if_test_overflow_complex"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/if_overflow_complex/src/main.nr
+++ b/test_programs/formal_verify_success/if_overflow_complex/src/main.nr
@@ -1,0 +1,14 @@
+// This test is slightly more complex
+// because it conatins nested ifs
+fn main(x: u8) -> pub u8 {
+    if x >= 255 {
+        0
+    }
+    else {
+        if x > 12 {
+          x - 1
+        } else {
+          x + 1
+        }
+    }
+}


### PR DESCRIPTION
We had an issue where we would fail to verify correct Noir programs because we were directly translating the if optimization without taking into consideration the instruction `enable_side_effects_if`.

Now we take into consideration the instruction enable_side_effects_if. This way we are able to create `if` expressions which would be semantically equivalent to the ones in Noir's AST. Because we are generating VIR from SSA we have to reverse optimize some parts of the code which appears in the SSA.

Also added a few tests which show that we now properly translate if-else statements.

