### PR TITLE
fix(fv): Fix regression caused by #e89646

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -103,6 +103,7 @@ pub(crate) fn optimize_into_acir(
         options.force_brillig_output,
         options.print_codegen_timings,
         &options.emit_ssa,
+        false,
     )?
     .run_pass(Ssa::defunctionalize, "After Defunctionalization:")
     .run_pass(Ssa::remove_paired_rc, "After Removing Paired rc_inc & rc_decs:")
@@ -174,6 +175,7 @@ pub(crate) fn optimize_into_plonky2(
         false,
         options.print_codegen_timings,
         &options.emit_ssa,
+        false,
     )?
     .run_pass(Ssa::defunctionalize, "After Defunctionalization:")
     .run_pass(Ssa::remove_paired_rc, "After Removing Paired rc_inc & rc_decs:")
@@ -230,6 +232,7 @@ pub(crate) fn optimize_into_verus_vir(
         false,
         options.print_codegen_timings,
         &options.emit_ssa,
+        true,
     )?
     .run_pass(Ssa::defunctionalize, "After Defunctionalization:")
     .run_pass(Ssa::remove_paired_rc, "After Removing Paired rc_inc & rc_decs:")
@@ -526,8 +529,9 @@ impl SsaBuilder {
         force_brillig_runtime: bool,
         print_codegen_timings: bool,
         emit_ssa: &Option<PathBuf>,
+        is_formal_verification: bool,
     ) -> Result<SsaBuilder, RuntimeError> {
-        let ssa = ssa_gen::generate_ssa(program, force_brillig_runtime)?;
+        let ssa = ssa_gen::generate_ssa(program, force_brillig_runtime, is_formal_verification)?;
         if let Some(emit_ssa) = emit_ssa {
             let mut emit_ssa_dir = emit_ssa.clone();
             // We expect the full package artifact path to be passed in here,

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -48,6 +48,9 @@ pub(super) struct FunctionContext<'a> {
     /// requires attributes, so in the SSA we can replace it with the return value
     /// of the function. We use this inside codegen_ident to do just that.
     pub(super) return_value: Values,
+
+    /// Flag which indicates if we are generating SSA for formal verification
+    pub(super) is_formal_verification: bool,
 }
 
 /// Shared context for all functions during ssa codegen. This is the only
@@ -106,6 +109,7 @@ impl<'a> FunctionContext<'a> {
         parameters: &Parameters,
         runtime: RuntimeType,
         shared_context: &'a SharedContext,
+        is_formal_verification: bool,
     ) -> Self {
         let function_id = shared_context
             .pop_next_function_in_queue()
@@ -121,6 +125,7 @@ impl<'a> FunctionContext<'a> {
             shared_context,
             loops: Vec::new(),
             return_value: Tree::empty(),
+            is_formal_verification,
         };
         this.add_parameters_to_scope(parameters);
         this


### PR DESCRIPTION
With PR 130 we temporary broke `nargo execute` and `nargo prove`. With this commit we are applying a fix to the issue. Now `nargo execute` and `nargo prove` work like they used to.

All expected tests pass just like on the `formal-verification` branch. 
