### PR TITLE
fix(fv): Reverse the order for reporting errors

### DIFF
--- a/tooling/nargo_cli/src/cli/fv_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fv_cmd.rs
@@ -123,7 +123,8 @@ pub(crate) fn z3_verify(
             println!("Failed to deserialize: {}", line);
         }
     }
-
+    smt_outputs.reverse();
+    
     let verification_diagnostics: Vec<FileDiagnostic> = smt_outputs
         .into_iter()
         .map(|smt_output| smt_output_to_diagnostic(smt_output, &workspace_file_manager))


### PR DESCRIPTION
Something which I forgot to do in the original commit for better error reporting.
