### PR TITLE
feat(fv): Index arrays made of composite types

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/attributes.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/attributes.rs
@@ -26,6 +26,9 @@ fn func_attributes_to_vir_expr(
             if let Instruction::RangeCheck { .. } = instruction {
                 continue;
             }
+            if let Instruction::IncrementRc { .. } = instruction {
+                continue;
+            }
             if is_instruction_enable_side_effects(&instruction_id, dfg) {
                 current_context.side_effects_condition =
                     get_enable_side_effects_value_id(&instruction_id, dfg);

--- a/test_programs/formal_verify_success/index_composite_array_with_const/Nargo.toml
+++ b/test_programs/formal_verify_success/index_composite_array_with_const/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "index_composite_array_with_const"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/index_composite_array_with_const/src/main.nr
+++ b/test_programs/formal_verify_success/index_composite_array_with_const/src/main.nr
@@ -1,0 +1,5 @@
+struct A { first: i32, second: u32, }
+#[ensures(result == arr[1].second)]
+fn main(arr: [A;2]) -> pub u32 {
+    arr[1].second
+}

--- a/test_programs/formal_verify_success/index_composite_array_with_var_1/Nargo.toml
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "index_composite_array_with_var_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/index_composite_array_with_var_1/src/main.nr
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_1/src/main.nr
@@ -1,0 +1,7 @@
+struct A { first: i32, second: u32, }
+#[requires(x < 2)]
+#[ensures(result == arr[x].first)]
+fn main(arr: [A;2], x: u32) -> pub i32 {
+    arr[x].first
+}
+

--- a/test_programs/formal_verify_success/index_composite_array_with_var_2/Nargo.toml
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "index_composite_array_with_var_2"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/index_composite_array_with_var_2/src/main.nr
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_2/src/main.nr
@@ -1,0 +1,7 @@
+struct A { first: i32, second: u32, }
+#[requires(x < 2)]
+#[ensures(result == arr[x].second)]
+fn main(arr: [A;2], x: u32) -> pub u32 {
+    arr[x].second
+}
+

--- a/test_programs/formal_verify_success/index_composite_array_with_var_3/Nargo.toml
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "index_composite_array_with_var_3"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/index_composite_array_with_var_3/src/main.nr
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_3/src/main.nr
@@ -1,0 +1,20 @@
+struct A {
+    first: i32,
+    second: u32,
+    third: (u32, u32),
+}
+struct C {
+    a: u32,
+    b: [A; 32],
+}
+struct B {
+    x: [[A; 192]; 74],
+    y: ([A;19],(i16, bool, (i8, [(C, u32);5], u32), u16))
+}
+
+#[requires((x < 2) & (arr[x].y.1.2.1[x].0.b[x].third.0 == 1))]
+#[ensures(result == arr[x].y.1.2.1[x].0.b[x].third.0 / 2)]
+fn main(arr: [B;2], x: u32) -> pub u32 {
+    arr[x].y.1.2.1[x].0.b[x].third.0 / 2
+}
+

--- a/test_programs/formal_verify_success/index_composite_array_with_var_4/Nargo.toml
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_4/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "index_composite_array_with_var_4"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/index_composite_array_with_var_4/src/main.nr
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_4/src/main.nr
@@ -1,0 +1,11 @@
+struct A {
+    first: i32,
+    second: u32,
+}
+
+#[requires((x < 2) & (arr[x].second == 1))]
+#[ensures(result == 1)]
+fn main(arr: [A; 2], x: u32) -> pub u32 {
+   arr[x].second
+}
+

--- a/test_programs/formal_verify_success/index_composite_array_with_var_5/Nargo.toml
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_5/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "index_composite_array_with_var_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/index_composite_array_with_var_5/src/main.nr
+++ b/test_programs/formal_verify_success/index_composite_array_with_var_5/src/main.nr
@@ -1,0 +1,9 @@
+// Here we are testing for a structure which has fields
+// of the same type.
+struct A { first: u32, second: u32, }
+#[requires((x < 2) & (arr[x].first == 4) )]
+#[ensures(result == 4)]
+fn main(arr: [A;2], x: u32) -> pub u32 {
+    arr[x].first
+}
+


### PR DESCRIPTION
Added logic for properly indexing the flattened SSA arrays.

Noir SSA flattens arrays which are made of composite types (tuples, structs, arrays). This resulted in having heterogeneous arrays which can not be converted directly to Verus.

What we did to fix it is that we unflattened the array by making the inner type a tuple. We also added a special logic for calculating the index for the unflattened array and the index for the tuple.

Added tests which show off the new capabilities.