### PR TITLE
feat(fv): Support for mutating arrays made of primitive types

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
@@ -990,6 +990,13 @@ pub(crate) fn is_instruction_call_to_print(instruction_id: &InstructionId, dfg: 
     }
 }
 
+pub(crate) fn is_instruction_ind_dec_rc(instruction_id: &InstructionId, dfg: &DataFlowGraph) -> bool {
+    match &dfg[*instruction_id] {
+        Instruction::DecrementRc { .. } | Instruction::IncrementRc { .. } => true,
+        _ => false,
+    }
+}
+
 /// Returns a SSA block as an expression and
 /// the type of the SSA block's terminating instruction
 pub(crate) fn basic_block_to_exprx(
@@ -1009,6 +1016,7 @@ pub(crate) fn basic_block_to_exprx(
 
         if !is_instruction_enable_side_effects(instruction_id, dfg)
             && !is_instruction_call_to_print(instruction_id, dfg)
+            && !is_instruction_ind_dec_rc(instruction_id, dfg)
         {
             let statement = instruction_to_stmt(
                 &dfg[*instruction_id],

--- a/test_programs/formal_verify_failure/array_set_composite_types_1/Nargo.toml
+++ b/test_programs/formal_verify_failure/array_set_composite_types_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "array_set_composite_types_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/array_set_composite_types_1/src/main.nr
+++ b/test_programs/formal_verify_failure/array_set_composite_types_1/src/main.nr
@@ -1,0 +1,5 @@
+fn main(mut x: [(u32, i32); 5], y: i32, index: u32) -> pub [(u32, i32); 5] {
+    x[index].1 = y;
+    x
+}
+

--- a/test_programs/formal_verify_success/array_set_1/Nargo.toml
+++ b/test_programs/formal_verify_success/array_set_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "array_set"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/array_set_1/src/main.nr
+++ b/test_programs/formal_verify_success/array_set_1/src/main.nr
@@ -1,0 +1,7 @@
+#[requires(i < 5)]
+#[ensures(result[i] == y)]
+fn main(mut x: [u32; 5], i: u32, y: u32) -> pub [u32; 5] {
+    x[i] = y;
+    x
+}
+


### PR DESCRIPTION
With this pull request we now add the ability to formally verify code which contains array mutating instructions. For now you can only mutate arrays of primitive types but soon we will add the possibility for mutating all types of arrays.

I expect there to be conflicts when rebasing this branch after PR #138 has been merged into `formal-verification`. That's why I opened this PR as draft.