### PR TITLE
feat(fv): Parse quantifier expressions

### DIFF
--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -21,9 +21,7 @@ use crate::{
 };
 
 use super::{
-    ForBounds, FunctionReturnType, GenericTypeArgs, IntegerBitSize, ItemVisibility, Pattern,
-    Signedness, TraitImplItemKind, TypePath, UnresolvedGenerics, UnresolvedTraitConstraint,
-    UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression,
+    ForBounds, FunctionReturnType, GenericTypeArgs, IntegerBitSize, ItemVisibility, Pattern, QuantifierExpression, Signedness, TraitImplItemKind, TypePath, UnresolvedGenerics, UnresolvedTraitConstraint, UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -213,6 +211,10 @@ pub trait Visitor {
     }
 
     fn visit_if_expression(&mut self, _: &IfExpression, _: Span) -> bool {
+        true
+    }
+
+    fn visit_quantifier_expression(&mut self, _: &QuantifierExpression, _: Span) -> bool { 
         true
     }
 
@@ -849,6 +851,7 @@ impl Expression {
             ExpressionKind::Interned(id) => visitor.visit_interned_expression(*id),
             ExpressionKind::InternedStatement(id) => visitor.visit_interned_statement(*id),
             ExpressionKind::Error => visitor.visit_error_expression(),
+            ExpressionKind::Quantifier(quantifier_expression) => quantifier_expression.accept(self.span, visitor),
         }
     }
 }
@@ -931,6 +934,18 @@ impl CallExpression {
     pub fn accept_children(&self, visitor: &mut impl Visitor) {
         self.func.accept(visitor);
         visit_expressions(&self.arguments, visitor);
+    }
+}
+
+impl QuantifierExpression {
+    pub fn accept(&self, span: Span, visitor: &mut impl Visitor) {
+        if visitor.visit_quantifier_expression(self, span) {
+            self.accept_children(visitor);
+        }
+    }
+
+    pub fn accept_children(&self, visitor: &mut impl Visitor) {
+        self.body.accept(visitor);
     }
 }
 

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -75,6 +75,7 @@ impl<'context> Elaborator<'context> {
             }
             ExpressionKind::AsTraitPath(_) => todo!("Implement AsTraitPath"),
             ExpressionKind::TypePath(path) => return self.elaborate_type_path(path),
+            ExpressionKind::Quantifier(quantifier_expression) => todo!(),
         };
         let id = self.interner.push_expr(hir_expr);
         self.interner.push_expr_location(id, expr.span, self.file);

--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -5,12 +5,7 @@ use noirc_errors::Span;
 
 use crate::{
     ast::{
-        ArrayLiteral, AsTraitPath, AssignStatement, BlockExpression, CallExpression,
-        CastExpression, ConstrainStatement, ConstructorExpression, Expression, ExpressionKind,
-        ForBounds, ForLoopStatement, ForRange, GenericTypeArgs, IfExpression, IndexExpression,
-        InfixExpression, LValue, Lambda, LetStatement, Literal, MemberAccessExpression,
-        MethodCallExpression, Pattern, PrefixExpression, Statement, StatementKind, UnresolvedType,
-        UnresolvedTypeData,
+        ArrayLiteral, AsTraitPath, AssignStatement, BlockExpression, CallExpression, CastExpression, ConstrainStatement, ConstructorExpression, Expression, ExpressionKind, ForBounds, ForLoopStatement, ForRange, GenericTypeArgs, IfExpression, IndexExpression, InfixExpression, LValue, Lambda, LetStatement, Literal, MemberAccessExpression, MethodCallExpression, Pattern, PrefixExpression, QuantifierExpression, Statement, StatementKind, UnresolvedType, UnresolvedTypeData
     },
     hir_def::traits::TraitConstraint,
     node_interner::{InternedStatementKind, NodeInterner},
@@ -633,6 +628,11 @@ fn remove_interned_in_expression_kind(
         }
         ExpressionKind::Error => expr,
         ExpressionKind::InternedStatement(id) => remove_interned_in_statement_expr(interner, id),
+        ExpressionKind::Quantifier(quantifier_expression) => ExpressionKind::Quantifier(Box::new(QuantifierExpression {
+            quantifier_type: quantifier_expression.quantifier_type,
+            indexes: quantifier_expression.indexes,
+            body: remove_interned_in_expression(interner, quantifier_expression.body),
+        })),
     }
 }
 

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -1572,6 +1572,66 @@ mod tests {
 
         assert_fv_attribute_lexes_to_tokens(input, expected);
     }
+
+    #[test]
+    fn quantifier_forall(){
+        let input = r#"forall(|i| i < 5 ==> arr[i] == x)"#;
+
+        let expected = vec![
+            Token::Keyword(Keyword::Forall),
+            Token::LeftParen,
+            Token::Pipe,
+            Token::Ident("i".to_string()),
+            Token::Pipe,
+            Token::Ident("i".to_string()),
+            Token::Less,
+            Token::Int(5_i128.into()),
+            Token::Implication,
+            Token::Ident("arr".to_string()),
+            Token::LeftBracket,
+            Token::Ident("i".to_string()),
+            Token::RightBracket,
+            Token::Equal,
+            Token::Ident("x".to_string()),
+        ];
+
+        let mut lexer = Lexer::new(input);
+
+        for token in expected.into_iter() {
+            let got = lexer.next_token().unwrap();
+            assert_eq!(got, token);
+        }
+    }
+
+    #[test]
+    fn quantifier_exists(){
+        let input = r#"exists(|i| i < 5 & arr[i] == x)"#;
+
+        let expected = vec![
+            Token::Keyword(Keyword::Exists),
+            Token::LeftParen,
+            Token::Pipe,
+            Token::Ident("i".to_string()),
+            Token::Pipe,
+            Token::Ident("i".to_string()),
+            Token::Less,
+            Token::Int(5_i128.into()),
+            Token::Ampersand,
+            Token::Ident("arr".to_string()),
+            Token::LeftBracket,
+            Token::Ident("i".to_string()),
+            Token::RightBracket,
+            Token::Equal,
+            Token::Ident("x".to_string()),
+        ];
+
+        let mut lexer = Lexer::new(input);
+
+        for token in expected.into_iter() {
+            let got = lexer.next_token().unwrap();
+            assert_eq!(got, token);
+        }
+    }
     #[test]
     fn test_non_ascii_comments() {
         let cases = vec!["// 🙂", "// schön", "/* in the middle 🙂 of a comment */"];

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -1096,9 +1096,11 @@ pub enum Keyword {
     Dep,
     Else,
     Expr,
+    Exists,
     Field,
     Fn,
     For,
+    Forall,
     FormatString,
     FunctionDefinition,
     Global,
@@ -1189,6 +1191,8 @@ impl fmt::Display for Keyword {
             Keyword::Use => write!(f, "use"),
             Keyword::Where => write!(f, "where"),
             Keyword::While => write!(f, "while"),
+            Keyword::Exists => write!(f, "exists"),
+            Keyword::Forall => write!(f, "forall"),
         }
     }
 }
@@ -1249,6 +1253,8 @@ impl Keyword {
             "use" => Keyword::Use,
             "where" => Keyword::Where,
             "while" => Keyword::While,
+            "exists" => Keyword::Exists,
+            "forall" => Keyword::Forall,
 
             "true" => return Some(Token::Bool(true)),
             "false" => return Some(Token::Bool(false)),

--- a/test_programs/formal_verify_failure/exists_big_element_sum/Nargo.toml
+++ b/test_programs/formal_verify_failure/exists_big_element_sum/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "exists_big_element_sum"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/exists_big_element_sum/src/main.nr
+++ b/test_programs/formal_verify_failure/exists_big_element_sum/src/main.nr
@@ -1,0 +1,10 @@
+#[requires(exists(|i| 0 <= i < 20 & arr[i] > 100))]
+#[ensures(result > 100)] // We require that an element bigger than 100 exists in the array.
+// Therefore we expect the sum to be bigger than 100.
+fn main(arr: [u16; 20]) -> pub u64 {
+    let mut sum: u64 = 0;
+    for i in 0..20 {
+        sum += arr[i] as u64;
+    }
+    sum
+}

--- a/test_programs/formal_verify_failure/exists_zero_in_array/Nargo.toml
+++ b/test_programs/formal_verify_failure/exists_zero_in_array/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "exists_zero_in_array"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/exists_zero_in_array/src/main.nr
+++ b/test_programs/formal_verify_failure/exists_zero_in_array/src/main.nr
@@ -1,0 +1,9 @@
+#[requires(exists(|i| (0 <= i < 7) & (arr[i] == 0) ) )]
+#[ensures(result == 0)]
+fn main(arr: [u8; 7]) -> pub u64 {
+    let mut mul: u64 = 0;
+    for i in 0..7 {
+        mul *= arr[i] as u64;
+    }
+    mul
+}

--- a/test_programs/formal_verify_failure/forall_max_is_max/Nargo.toml
+++ b/test_programs/formal_verify_failure/forall_max_is_max/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "forall_max_is_max"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/forall_max_is_max/src/main.nr
+++ b/test_programs/formal_verify_failure/forall_max_is_max/src/main.nr
@@ -1,0 +1,5 @@
+#[requires(forall(|i, j| 0 <= i < j < 15 ==> v[i] <= v[j]))]
+#[ensures(forall(|i| 0 <= i < 15 ==> v[i] <= result))]
+fn main(v: [u64; 15], k: u64) -> pub u64 {
+    v[14] // The array is sorted and this is the last element, therefore it's the maximum element.  
+}

--- a/test_programs/formal_verify_failure/forall_sum_of_evens/Nargo.toml
+++ b/test_programs/formal_verify_failure/forall_sum_of_evens/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "forall_sum_of_evens"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/forall_sum_of_evens/src/main.nr
+++ b/test_programs/formal_verify_failure/forall_sum_of_evens/src/main.nr
@@ -1,0 +1,12 @@
+#[requires(forall(|i| 0 <= i < 10 ==> arr[i] % 2 == 0) 
+            & forall(|i| 0 <= i < 10 ==> arr[i] < 100) )]
+#[ensures((result % 2 == 0) & (result < 1000))]
+// The sum of an array which constist of even elements upper bounded by 100
+// will be even and upper bounded by 1000
+fn foo(arr: [u32; 10]) -> pub u32 {
+    let mut sum = 0;
+    for i in 0..10 {
+        sum += arr[i];
+    }
+    sum
+}

--- a/tooling/lsp/src/requests/completion/builtins.rs
+++ b/tooling/lsp/src/requests/completion/builtins.rs
@@ -150,6 +150,7 @@ pub(super) fn keyword_builtin_type(keyword: &Keyword) -> Option<&'static str> {
         Keyword::TypedExpr => Some("TypedExpr"),
         Keyword::TypeType => Some("Type"),
         Keyword::UnresolvedType => Some("UnresolvedType"),
+        Keyword::Forall | Keyword::Exists => Some("bool"),
 
         Keyword::As
         | Keyword::Assert
@@ -226,9 +227,11 @@ pub(super) fn keyword_builtin_function(keyword: &Keyword) -> Option<BuiltInFunct
         | Keyword::Dep
         | Keyword::Else
         | Keyword::Expr
+        | Keyword::Exists
         | Keyword::Field
         | Keyword::Fn
         | Keyword::For
+        | Keyword::Forall
         | Keyword::FormatString
         | Keyword::FunctionDefinition
         | Keyword::Global

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -532,6 +532,7 @@ fn get_expression_name(expression: &Expression) -> Option<String> {
         | ExpressionKind::InternedStatement(..)
         | ExpressionKind::Literal(..)
         | ExpressionKind::Unsafe(..)
+        | ExpressionKind::Quantifier(..)
         | ExpressionKind::Error => None,
     }
 }

--- a/tooling/nargo_fmt/src/rewrite/expr.rs
+++ b/tooling/nargo_fmt/src/rewrite/expr.rs
@@ -208,6 +208,19 @@ pub(crate) fn rewrite(
                 format!("{}::{}::{}", path.typ, path.item, path.turbofish)
             }
         }
+        ExpressionKind::Quantifier(quantifier_expression) => {
+            format!(
+                "{}(|{}| {})",
+                quantifier_expression.quantifier_type,
+                quantifier_expression
+                    .indexes
+                    .iter()
+                    .map(|ident| ident.0.contents.as_str())
+                    .collect::<Vec<&str>>()
+                    .join(", "),
+                rewrite_sub_expr(visitor, shape, quantifier_expression.body)
+            )
+        }
     }
 }
 


### PR DESCRIPTION
We can now parse quantifier expressions.
Added unit tests which show off the new capabilities of the parser.
