### PR TITLE
Several workarounds for tracing: record event before a step; don't record a <toplevel> call 

### DIFF
--- a/tooling/tracer/src/lib.rs
+++ b/tooling/tracer/src/lib.rs
@@ -23,7 +23,7 @@ use nargo::NargoError;
 use noir_debugger::context::{DebugCommandResult, DebugContext};
 use noir_debugger::foreign_calls::DefaultDebugForeignCallExecutor;
 use noirc_artifacts::debug::DebugArtifact;
-use runtime_tracing::{Line, Tracer};
+use runtime_tracing::{Line, Tracer, TypeKind};
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -213,7 +213,7 @@ pub fn trace_circuit<B: BlackBoxFunctionSolver<FieldElement>>(
     }
 
     let SourceLocation { filepath, line_number } = SourceLocation::create_unknown();
-    tracer.start(&PathBuf::from(filepath.to_string()), Line(line_number as i64));
+    let _ = tracer.ensure_type_id(TypeKind::None, "None");
     loop {
         let source_locations = match tracing_context.step_debugger() {
             DebugStepResult::Finished => break,


### PR DESCRIPTION
# Description


*    record event before a step, not after, as @nikolay Nikolov suggested
*   don't record a <toplevel> call: (so, skip our tracer start() call for now): was leading to problems for our logic, and noir has main, not scripting language-like toplevel code:

now we're calling `ensure_type_id` for None manually here, which is an internal detail for the tracing lib: probably we need to add a flag or a separate method to `runtime_tracing` but i hope this is ok for now ?



## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
