### PR TITLE
fix(trace): stop using `start()`: don't record a toplevel call

### DIFF
--- a/tooling/tracer/src/lib.rs
+++ b/tooling/tracer/src/lib.rs
@@ -23,7 +23,7 @@ use nargo::NargoError;
 use noir_debugger::context::{DebugCommandResult, DebugContext};
 use noir_debugger::foreign_calls::DefaultDebugForeignCallExecutor;
 use noirc_artifacts::debug::DebugArtifact;
-use runtime_tracing::{Line, Tracer};
+use runtime_tracing::{Line, Tracer, TypeKind};
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -213,7 +213,7 @@ pub fn trace_circuit<B: BlackBoxFunctionSolver<FieldElement>>(
     }
 
     let SourceLocation { filepath, line_number } = SourceLocation::create_unknown();
-    tracer.start(&PathBuf::from(filepath.to_string()), Line(line_number as i64));
+    let _ = tracer.ensure_type_id(TypeKind::None, "None");
     loop {
         let source_locations = match tracing_context.step_debugger() {
             DebugStepResult::Finished => break,


### PR DESCRIPTION
it was leading to more problems as there isn't really toplevel code before `main` for noir, and probably not really steps

probably we need to add a flag or a separate method to `runtime_tracing` but i hope this is ok for now?

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
