### PR TITLE
feat(fv): Truncate referenced SSA values

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
@@ -431,6 +431,16 @@ fn range_limit_to_expr(
             },
             ssa_value_to_expr(value_id, dfg, result_id_fixer),
         ),
+        Type::Reference(inner_type) => match inner_type.as_ref() {
+            Type::Numeric(numeric_type) => ExprX::Unary(
+                UnaryOp::Clip {
+                    range: trunc_target_int_range(numeric_type, target_bit_size),
+                    truncate,
+                },
+                ssa_value_to_expr(value_id, dfg, result_id_fixer),
+            ),
+            _ => panic!("Can range limit/truncate only numeric values"),
+        },
         _ => panic!("Can range limit/truncate only numeric values"),
     };
 

--- a/test_programs/formal_verify_failure/is_even/Nargo.toml
+++ b/test_programs/formal_verify_failure/is_even/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "is_even"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/is_even/src/main.nr
+++ b/test_programs/formal_verify_failure/is_even/src/main.nr
@@ -1,0 +1,12 @@
+#[requires((x % 2 == 0) & (z % 2 == 0) & (x < z ) & (z < 1000))]
+#[ensures(result == 1)]
+fn main(x: u32, z: u32) -> pub u32 {
+    let mut y = x + z;
+    let w = y % 2;
+    if w == 0{
+        1
+    } else {
+        0
+    }
+}
+


### PR DESCRIPTION
We now handle SSA expression which truncate SSA values of type reference. Before we assumed that truncation could only be possible with values of type integer.

Added a test which shows the generation of such instructions. The test is currently failing because Verus is not able to prove that the sum of two numbers where the last bit is 0 the result will also have a last bit 0.

