### PR TITLE
cleanup: shorten the "saved trace" message to one line; fix error for paths

### DIFF
--- a/tooling/tracer/src/tracer_glue.rs
+++ b/tooling/tracer/src/tracer_glue.rs
@@ -14,21 +14,34 @@ use tracing::warn;
 /// multiple JSON files.
 pub fn store_trace(tracer: Tracer, trace_dir: &str) {
     let trace_path = Path::new(trace_dir).join("trace.json");
+    let mut storing_errors = false;
     match tracer.store_trace_events(&trace_path) {
-        Ok(_) => println!("Saved trace to {:?}", trace_path),
-        Err(err) => println!("Warning: tracer failed to store trace events: {err}"),
+        Ok(_) => {}
+        Err(err) => {
+            storing_errors = true;
+            println!("Warning: tracer failed to store trace events: {err}")
+        }
     }
 
     let trace_path = Path::new(trace_dir).join("trace_metadata.json");
     match tracer.store_trace_metadata(&trace_path) {
-        Ok(_) => println!("Saved trace to {:?}", trace_path),
-        Err(err) => println!("Warning: tracer failed to store trace metadata: {err}"),
+        Ok(_) => {}
+        Err(err) => {
+            storing_errors = true;
+            println!("Warning: tracer failed to store trace metadata: {err}")
+        }
     }
 
     let trace_path = Path::new(trace_dir).join("trace_paths.json");
     match tracer.store_trace_paths(&trace_path) {
-        Ok(_) => println!("Saved trace to {:?}", trace_path),
-        Err(err) => println!("Warning: tracer failed to store trace metadata: {err}"),
+        Ok(_) => {}
+        Err(err) => {
+            storing_errors = true;
+            println!("Warning: tracer failed to store trace paths: {err}")
+        }
+    }
+    if !storing_errors {
+        println!("Saved trace to {}", trace_dir);
     }
 }
 


### PR DESCRIPTION
part of small cleanup of our logging/printed messages

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
