### PR TITLE
fix(fv): Fix incorrect load instructions in annotations

### DIFF
--- a/test_programs/formal_verify_success/load_store_instructions/Nargo.toml
+++ b/test_programs/formal_verify_success/load_store_instructions/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "load_store_instructions"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/load_store_instructions/src/main.nr
+++ b/test_programs/formal_verify_success/load_store_instructions/src/main.nr
@@ -1,0 +1,6 @@
+#[requires(x[3].0 == -2)]
+#[requires(i < 5)]
+fn main(mut x: [(i32, u32); 5], i: u32, y: u32) -> pub [(i32, u32); 5] {
+    x[i].1 = y;
+    x
+}


### PR DESCRIPTION
Before this fix the newly added test was generating incorrect load instruction inside of the require annotation body.

With the added patch we now correct the load instruction to load the proper value. This is being done during the mem2reg optimization where store and load instructions are being optimized away. It's a convinient place where we can do this optimization.

