### PR TITLE
fix(fv): Fix inlining of function which have `store` as a last instructions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -846,7 +846,7 @@ impl<'a> FunctionContext<'a> {
         body: &Expression,
     ) -> Result<Values, RuntimeError> {
         let mut index_to_val_id: HashMap<&str, ValueId> = HashMap::new();
-        
+
         indexes.iter().for_each(|ident| {
             if let ast::Definition::Local(id) = ident.definition {
                 let converted_type = FunctionContext::<'a>::convert_non_tuple_type(&ident.typ);
@@ -875,7 +875,10 @@ impl<'a> FunctionContext<'a> {
         self.builder.insert_instruction(new_instruction, None);
 
         let body_values = self.codegen_expression(body)?;
-        assert!(body_values.count_leaves() == 1, "Quant body expressions result should be only one");
+        assert!(
+            body_values.count_leaves() == 1,
+            "Quant body expressions result should be only one"
+        );
 
         let quant_end_instruction = Instruction::QuantEnd {
             quant_type: *quant,

--- a/test_programs/formal_verify_success/is_sorted_no_quant/Nargo.toml
+++ b/test_programs/formal_verify_success/is_sorted_no_quant/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "is_sorted_no_quant"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/is_sorted_no_quant/src/main.nr
+++ b/test_programs/formal_verify_success/is_sorted_no_quant/src/main.nr
@@ -1,0 +1,13 @@
+fn is_ascending_sorted(arr: [u64; 3]) -> bool {
+    let mut is_sorted: bool = true;
+    for i in 0..2 {
+        if arr[i] > arr[i + 1] {
+            is_sorted = false;
+        }
+    }
+    is_sorted
+}
+#[requires(arr[0] <= arr[1])]
+#[requires(arr[1] <= arr[2])]
+#[ensures(is_ascending_sorted(arr))]
+fn main(arr: [u64; 3]) {}


### PR DESCRIPTION
More details on the bug and how it was fixed can be found in the commit description.

Added a test which has a function which generates SSA with a last instruction `store`.