### PR TITLE
fix(fv): Map Field type to signed 254 bits

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/types.rs
@@ -39,7 +39,7 @@ pub(crate) fn from_numeric_type(numeric_type: NumericType) -> Typ {
                 Arc::new(TypX::Int(IntRange::U(bit_size)))
             }
         }
-        NumericType::NativeField => Arc::new(TypX::Int(IntRange::U(FieldElement::max_num_bits()))), // TODO(totel) Document mapping Noir Fields
+        NumericType::NativeField => Arc::new(TypX::Int(IntRange::I(FieldElement::max_num_bits()))),
     }
 }
 


### PR DESCRIPTION
We were previously mapping the Field type to unsigned 254 bit integer type which was incorrect.
