### PR TITLE
docs(noir): Add introduction page and information about CT

### DIFF
--- a/formal_verification_docs/src/SUMMARY.md
+++ b/formal_verification_docs/src/SUMMARY.md
@@ -14,4 +14,6 @@
 - [Noir PLONKY2 Backend](./noir_plonky2_backend/README.md)
   - [Getting Started](./noir_plonky2_backend/getting_started.md)
 - [Noir Tracer](./noir_tracer/README.md)
+  - [Debugging with CodeTracer](./noir_tracer/debugging_with_codetracer.md)
+
 

--- a/formal_verification_docs/src/SUMMARY.md
+++ b/formal_verification_docs/src/SUMMARY.md
@@ -1,5 +1,6 @@
 # Summary
 
+- [Blocksense Noir](./blocksense_noir.md)
 - [Noir Formal Verification](./noir_formal_verification/README.md)
   - [Getting Started](./noir_formal_verification/getting_started.md)
   - [Specifications](./noir_formal_verification/specifications/README.md)

--- a/formal_verification_docs/src/blocksense_noir.md
+++ b/formal_verification_docs/src/blocksense_noir.md
@@ -1,10 +1,10 @@
 # Blocksense Noir
 
-At Blocksense, we’ve enhanced the Noir programming language and compiler with advanced tools designed to simplify and strengthen the creation of secure, verifiable circuits. Our current features include:
+At Blocksense, we’ve enhanced the Noir programming language and compiler with advanced tools designed to simplify and strengthen the creation of secure, verifiable circuits. Our current prototypes include:
 
-  1. [Noir time-travel](./noir_tracer) debugging in the [CodeTracer](https://github.com/metacraft-labs/codetracer) environment.
+  1. [Noir time-travel debugging](./noir_tracer) in the [CodeTracer](https://github.com/metacraft-labs/codetracer) environment;
    
-  2. [Formal verification](./noir_formal_verification) of Noir circuits, based on the Z3 SMT solver and the IR language of the [Verus project](https://github.com/verus-lang/verus).
+  2. [formal verification](./noir_formal_verification) of Noir circuits, based on the Z3 SMT solver and the IR language of the [Verus project](https://github.com/verus-lang/verus); and
    
   3. [Noir compilation support](./noir_plonky2_backend) for the PLONKY2 proof system.
     

--- a/formal_verification_docs/src/blocksense_noir.md
+++ b/formal_verification_docs/src/blocksense_noir.md
@@ -1,0 +1,13 @@
+# Blocksense Noir
+
+At Blocksense, we’ve enhanced the Noir programming language and compiler with advanced tools designed to simplify and strengthen the creation of secure, verifiable circuits. Our current features include:
+
+  1. [Noir time-travel](./noir_tracer) debugging in the [CodeTracer](https://github.com/metacraft-labs/codetracer) environment.
+   
+  2. [Formal verification](./noir_formal_verification) of Noir circuits, based on the Z3 SMT solver and the IR language of the [Verus project](https://github.com/verus-lang/verus).
+   
+  3. [Noir compilation support](./noir_plonky2_backend) for the PLONKY2 proof system.
+    
+All of these developments are expected to reach a production-ready status in the future. We plan on merging them with the upstream codebase as soon as they are accepted by the Noir team.
+
+The Blocksense Noir compiler follows the development of upstream Noir closely and it should be fully compatible.

--- a/formal_verification_docs/src/noir_tracer/README.md
+++ b/formal_verification_docs/src/noir_tracer/README.md
@@ -12,11 +12,12 @@ powerful enough to handle a broad range of Noir programs.
 
 We are using the [runtime
 tracing](https://github.com/metacraft-labs/runtime_tracing) Rust library for
-the tracing format.
-
-An alternative workflow is provided by [CodeTracer](https://github.com/metacraft-labs/codetracer): a time traveling debugger with built-in support for Noir. With it you may traverse the execution timeline forwards and backwards in an intuitive GUI.
-
-More details can be found in section [Debugging with CodeTracer](#debugging-with-codetracer)
+the tracing format. Thanks to this, we have enabled the use of the time
+traveling debugger [CodeTracer](https://github.com/metacraft-labs/codetracer).
+With it you may traverse the execution timeline forwards and backwards in an
+intuitive GUI. More details about it can be found in the subpage [Debugging
+with
+CodeTracer](https://noir.blocksense.network/noir_tracer/debugging_with_codetracer).
 
 ## Installation
 
@@ -141,11 +142,3 @@ all the variables live at each step. Again, this is an early prototype and we
 are in the process of heavily optimizing it, including smart tracking of
 variables and reducing unnecessary repetition so that we keep the file size to
 a minimum.
-
-## Debugging with CodeTracer
-
-After installing [CodeTracer](https://github.com/metacraft-labs/codetracer), you can launch any Noir program with `ct run <program-folder>` to benefit from the powerful debugging experience.
-
-An example of using CodeTracer with Noir can be found in the demonstration video:
-
-[![Watch the video](https://img.youtube.com/vi/xZsJ55JVqmU/maxresdefault.jpg)](https://www.youtube.com/watch?v=xZsJ55JVqmU)

--- a/formal_verification_docs/src/noir_tracer/README.md
+++ b/formal_verification_docs/src/noir_tracer/README.md
@@ -14,6 +14,10 @@ We are using the [runtime
 tracing](https://github.com/metacraft-labs/runtime_tracing) Rust library for
 the tracing format.
 
+An alternative workflow is provided by [CodeTracer](https://github.com/metacraft-labs/codetracer): a time traveling debugger with built-in support for Noir. With it you may traverse the execution timeline forwards and backwards in an intuitive GUI.
+
+More details can be found in section [Debugging with CodeTracer](#debugging-with-codetracer)
+
 ## Installation
 
 As already mentioned, the tool is integrated in the `nargo` CLI, but you need
@@ -137,3 +141,11 @@ all the variables live at each step. Again, this is an early prototype and we
 are in the process of heavily optimizing it, including smart tracking of
 variables and reducing unnecessary repetition so that we keep the file size to
 a minimum.
+
+## Debugging with CodeTracer
+
+After installing [CodeTracer](https://github.com/metacraft-labs/codetracer), you can launch any Noir program with `ct run <program-folder>` to benefit from the powerful debugging experience.
+
+An example of using CodeTracer with Noir can be found in the demonstration video:
+
+[![Watch the video](https://img.youtube.com/vi/xZsJ55JVqmU/maxresdefault.jpg)](https://www.youtube.com/watch?v=xZsJ55JVqmU)

--- a/formal_verification_docs/src/noir_tracer/debugging_with_codetracer.md
+++ b/formal_verification_docs/src/noir_tracer/debugging_with_codetracer.md
@@ -1,0 +1,11 @@
+# Debugging with CodeTracer
+
+After installing [CodeTracer](https://github.com/metacraft-labs/codetracer),
+you can launch any Noir program with `ct run <program-folder>` to benefit from
+the powerful debugging experience.
+
+An example of using CodeTracer with Noir can be found in the demonstration
+video:
+
+[![Watch the
+video](https://img.youtube.com/vi/xZsJ55JVqmU/maxresdefault.jpg)](https://www.youtube.com/watch?v=xZsJ55JVqmU)


### PR DESCRIPTION
Added an introduction page. Also we now mention CodeTracer. Added "Debugging with CodeTracer" header in the Noir Tracer page.