### PR TITLE
fix(fv): Remove let array vars from triggers

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/context.rs
@@ -131,21 +131,35 @@ impl QuantifierContext {
     }
 }
 
+pub(crate) struct FunctionDetails {
+    function_return_args: Vec<ValueId>,
+}
+
+impl FunctionDetails {
+    pub(crate) fn get_current_function_ret_vals(&self) -> &Vec<ValueId> {
+        &self.function_return_args
+    }
+}
+
 pub(crate) struct SSAContext<'a> {
     pub result_id_fixer: Option<&'a ResultIdFixer>,
     pub side_effects_condition: Option<ValueId>,
     pub quantifier_context: QuantifierContext,
+    pub function_details: FunctionDetails,
 }
 
 impl<'a> SSAContext<'a> {
     pub(crate) fn new(
         result_id_fixer: Option<&'a ResultIdFixer>,
         side_effects_condition: Option<ValueId>,
+        function_return_args: Vec<ValueId>,
     ) -> Self {
+        let function_details = FunctionDetails { function_return_args };
         SSAContext {
             result_id_fixer,
             side_effects_condition,
             quantifier_context: QuantifierContext::new(),
+            function_details,
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/function.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/function.rs
@@ -96,7 +96,8 @@ pub(crate) fn build_funx(
 
     let ret = get_function_return_param(func)?;
     let result_id_fixer = ResultIdFixer::new(func, &ret).ok();
-    let mut current_context = SSAContext::new(result_id_fixer.as_ref(), None);
+    let return_val_ids = get_function_return_values(func)?;
+    let mut current_context = SSAContext::new(result_id_fixer.as_ref(), None, return_val_ids);
 
     let funx: FunctionX = FunctionX {
         name: func_id_into_funx_name(func_id),

--- a/test_programs/formal_verify_success/array_let_var_in_trigger/Nargo.toml
+++ b/test_programs/formal_verify_success/array_let_var_in_trigger/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "apply_transactions"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/array_let_var_in_trigger/src/main.nr
+++ b/test_programs/formal_verify_success/array_let_var_in_trigger/src/main.nr
@@ -1,0 +1,39 @@
+struct Account {
+    id: Field,
+    balance: u32,
+}
+type Action = u8;
+global ACTION_WITHDRAW: u8 = 0;
+global ACTION_DEPOSIT: u8 = 1;
+
+struct Transaction {
+    account_id: Field,
+    sum: u32,
+    action: Action,
+}
+
+mod annotation_helpers {
+    use super::Account;
+    use super::Transaction;
+    use super::ACTION_WITHDRAW;
+    #[requires(account.balance > transaction.sum)]
+    #[requires(account.balance < 1000000)]
+    fn apply_transaction(account: Account, transaction: Transaction) -> u32 {
+        if transaction.action == ACTION_WITHDRAW {
+            account.balance - transaction.sum
+        } else {
+            account.balance + transaction.sum
+        }
+    }
+}
+#[requires(forall(|i, j| (0 <= i) & (i < 2) & (0 <= j) & (j < 2) ==>
+         (transactions[j].account_id == accounts[i].id ==> param.0[i].balance == annotation_helpers::apply_transaction(accounts[i], transactions[j])) ))]
+fn main(
+    mut accounts: [Account; 2],
+    transactions: [Transaction; 2],
+    param: ([Account; 2], [bool; 2])
+) -> pub ([Account; 2], [bool; 2]) {
+    let mut transactions_success_status: [bool; 2] = [false; 2];
+    (accounts, transactions_success_status)
+}
+


### PR DESCRIPTION
In a previous fix we didn't consider the possibility of arrays being a let defined variables. We now have handled this case.

Also previously we had missed a corner case for the recursion. If you encounter one of the return parameters of the function you would want the recursion to end.
Now we add the return value ids of a function to recursion bottom set.
