### PR TITLE
test(fv): Add failing tests for `if` bug

### DIFF
--- a/test_programs/formal_verify_failure/func_call_in_if/Nargo.toml
+++ b/test_programs/formal_verify_failure/func_call_in_if/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "func_call_in_if"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/func_call_in_if/src/main.nr
+++ b/test_programs/formal_verify_failure/func_call_in_if/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: u32) -> pub u32 {
+    if x > 5 { foo(x) } else { x }
+}
+
+#[requires(x > 5)]
+fn foo(x: u32) -> u32 {
+    0
+}

--- a/test_programs/formal_verify_failure/obvious_assert/Nargo.toml
+++ b/test_programs/formal_verify_failure/obvious_assert/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "obvious_assert"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/obvious_assert/src/main.nr
+++ b/test_programs/formal_verify_failure/obvious_assert/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: u32) {
+    if x == 0 {
+        assert(x == 0);
+    } else {
+        assert(x != 0);
+    }
+}
+


### PR DESCRIPTION
We are wrapping only some expressions with an `if` clause when we encounter the instruction `enable_side_effects` in the program's SSA. Before we thought that only binary expressions required `if` wrapping because they can lead to overflows.

The tests which are being added contain examples where not wrapping the expressions of type function call and assert can cause formal verification failure.
