### PR TITLE
fix(fv): Do not wrap with `if` `lt` instructions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
@@ -356,8 +356,8 @@ fn binary_instruction_to_expr(
     );
 
     if let Some(condition_id) = current_context.side_effects_condition {
-        if !matches!(operator, BinaryOp::Eq) {
-            // Eq is not a dangerous operation
+        if !matches!(operator, BinaryOp::Eq | BinaryOp::Lt) {
+            // Eq and Lt are not dangerous operations
             return wrap_with_an_if_logic(
                 condition_id,
                 binary_expr,

--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/exprs.rs
@@ -356,8 +356,10 @@ fn binary_instruction_to_expr(
     );
 
     if let Some(condition_id) = current_context.side_effects_condition {
-        if !matches!(operator, BinaryOp::Eq | BinaryOp::Lt) {
-            // Eq and Lt are not dangerous operations
+        if !matches!(operator, BinaryOp::Eq | BinaryOp::Lt | BinaryOp::Xor) {
+            // Eq, Lt and Xor are not dangerous operations.
+            // Although And and Or are safe operations, they never reach here because
+            // we handle them in an earlier branch.
             return wrap_with_an_if_logic(
                 condition_id,
                 binary_expr,


### PR DESCRIPTION
Before we wrapping the `lt` instruction with an `if` expression if it was located inside of an `enable side_effects` block.

This was not needed because `lt` is not a dangerous instruction.

It also caused crashes in the case of `v21 = lt v20 v5` because `v21` is of type `bool` and the default value for the `else` clause of the `if` wrapper was of a type `Int`.
