### PR TITLE
fix(fv): Correct type translation for Field

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/verus_vir_gen/expr_to_vir/types.rs
@@ -17,7 +17,7 @@ pub(crate) fn get_int_range(numeric_type: NumericType) -> IntRange {
     match numeric_type {
         NumericType::Signed { bit_size } => IntRange::I(bit_size),
         NumericType::Unsigned { bit_size } => IntRange::U(bit_size),
-        NumericType::NativeField => IntRange::U(FieldElement::max_num_bits()), // TODO(totel) Document mapping Noir Fields
+        NumericType::NativeField => IntRange::I(FieldElement::max_num_bits()), // TODO(totel) Document mapping Noir Fields
     }
 }
 
@@ -25,7 +25,7 @@ pub(crate) fn trunc_target_int_range(numeric_type: &NumericType, target_bit_size
     match numeric_type {
         NumericType::Signed { bit_size: _ } => IntRange::I(target_bit_size),
         NumericType::Unsigned { bit_size: _ } => IntRange::U(target_bit_size),
-        NumericType::NativeField => IntRange::U(target_bit_size),
+        NumericType::NativeField => IntRange::I(target_bit_size),
     }
 }
 


### PR DESCRIPTION
In #203 we missed out on correcting some functions which translate the Noir Field type to a VIR type.