### PR TITLE
test(fv): Formal verification limit for Field type

### DIFF
--- a/test_programs/formal_verify_failure/field_type_limit/Nargo.toml
+++ b/test_programs/formal_verify_failure/field_type_limit/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "field_type_limit"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/field_type_limit/src/main.nr
+++ b/test_programs/formal_verify_failure/field_type_limit/src/main.nr
@@ -1,0 +1,5 @@
+#[requires((x == 0) | (x == 1))]
+fn main(x: Field) -> pub Field {
+    x + 1
+}
+

--- a/test_programs/formal_verify_failure/field_type_limit_2/Nargo.toml
+++ b/test_programs/formal_verify_failure/field_type_limit_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "field_type_limit_2"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/field_type_limit_2/src/main.nr
+++ b/test_programs/formal_verify_failure/field_type_limit_2/src/main.nr
@@ -1,0 +1,4 @@
+fn main(x: bool) -> pub Field {
+    (x as Field) + 1
+}
+

--- a/test_programs/formal_verify_success/cast_to_avoid_field/Nargo.toml
+++ b/test_programs/formal_verify_success/cast_to_avoid_field/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cast_to_avoid_field"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/cast_to_avoid_field/src/main.nr
+++ b/test_programs/formal_verify_success/cast_to_avoid_field/src/main.nr
@@ -1,0 +1,5 @@
+#[requires((x == 0) | (x == 1))]
+fn main(x: Field) -> pub Field {
+    ((x as u32) + 1) as Field
+}
+


### PR DESCRIPTION
Added tests which do basic arithmetic operation with a variable of type `Field`. They fail to verify successfully because Verus does not support logical reasoning for integer types with a bit size different from `8`, `16`, `32`, `64`, `128`.

The default Noir `Field` is of bit size `254`.

Added a test which shows that casting from Field to another type and then doing the mathematical operation is verified successfully.

We have opened an issue in Verus asking if they are actually planning a support for odd int types.
https://github.com/verus-lang/verus/issues/1503
