### PR TITLE
chore(acvm): Bump blake3 version to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,16 +740,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
+checksum = "b17679a8d69b6d7fd9cd9801a536cec9fa5e5970b69f9d4747f70b39b031f5e7"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "memmap2",
 ]
 
 [[package]]

--- a/acvm-repo/blackbox_solver/Cargo.toml
+++ b/acvm-repo/blackbox_solver/Cargo.toml
@@ -21,7 +21,7 @@ thiserror.workspace = true
 num-bigint = "0.4"
 
 blake2 = "0.10.6"
-blake3 = "1.5.0"
+blake3 = "1.7.0"
 sha2.workspace = true
 keccak = "0.1.4"
 k256 = { version = "0.11.0", features = [


### PR DESCRIPTION
This is a blocker for the CodeTracer team and their goal to make Noir compatible for Windows OS.
With upgrading the version of blake3 from 1.6.0 to 1.7.0 this is issue is resolved.
