### PR TITLE
chore(errors): Remove deprecated `FilesystemError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,6 +3287,7 @@ dependencies = [
  "color-eyre",
  "const_format",
  "fm",
+ "hex",
  "nargo",
  "noirc_abi",
  "noirc_artifacts",

--- a/tooling/artifact_cli/Cargo.toml
+++ b/tooling/artifact_cli/Cargo.toml
@@ -41,3 +41,4 @@ noirc_artifacts.workspace = true
 noirc_driver.workspace = true
 noirc_errors.workspace = true
 serde.workspace = true
+hex.workspace = true

--- a/tooling/artifact_cli/src/errors.rs
+++ b/tooling/artifact_cli/src/errors.rs
@@ -5,6 +5,7 @@ use noirc_abi::{
     errors::{AbiError, InputParserError},
     input_parser::InputValue,
 };
+use hex::FromHexError;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -30,6 +31,9 @@ pub enum FilesystemError {
 
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+
+    #[error("Error: could not parse hex build artifact (proof, proving and/or verification keys, ACIR checksum) ({0})")]
+    HexArtifactNotValid(FromHexError),
 }
 
 #[derive(Debug, Error)]
@@ -39,7 +43,7 @@ pub enum CliError {
     FilesystemError(#[from] FilesystemError),
 
     /// Error related to ABI input deserialization
-    #[error("Failed to deserialize inputs")]
+    #[error(transparent)]
     InputDeserializationError(#[from] InputParserError),
 
     /// Error related to oracle transcript deserialization

--- a/tooling/nargo_cli/src/cli/fs/proof.rs
+++ b/tooling/nargo_cli/src/cli/fs/proof.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use nargo::constants::PROOF_EXT;
 
-use crate::errors::FilesystemError;
+use crate::errors::CliError;
 
 use super::{create_named_dir, write_to_file};
 
@@ -10,7 +10,7 @@ pub(crate) fn save_proof_to_dir<P: AsRef<Path>>(
     proof: &[u8],
     proof_name: &str,
     proof_dir: P,
-) -> Result<PathBuf, FilesystemError> {
+) -> Result<PathBuf, CliError> {
     create_named_dir(proof_dir.as_ref(), "proof");
     let proof_path = proof_dir.as_ref().join(proof_name).with_extension(PROOF_EXT);
 


### PR DESCRIPTION
This commit clears some technical debt which we had acquired during our daily syncs. Upstream have moved the type `FilesystemError` into a different file and also made it a part of the type `CliError`.

We made our code compatible with those changes.