### PR TITLE
feat(fv): Add nargo cli command for FV

### DIFF
--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -105,7 +105,7 @@ fn watch_workspace(workspace: &Workspace, compile_options: &CompileOptions) -> n
 }
 
 /// Parse all files in the workspace.
-fn parse_workspace(workspace: &Workspace) -> (FileManager, ParsedFiles) {
+pub(crate) fn parse_workspace(workspace: &Workspace) -> (FileManager, ParsedFiles) {
     let mut file_manager = workspace.new_file_manager();
     insert_all_files_for_workspace_into_file_manager(workspace, &mut file_manager);
     let parsed_files = parse_all(&file_manager);

--- a/tooling/nargo_cli/src/cli/fv_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fv_cmd.rs
@@ -1,0 +1,38 @@
+use clap::Args;
+use nargo::workspace::Workspace;
+use nargo_toml::PackageSelection;
+use noirc_driver::CompileOptions;
+
+use crate::errors::CliError;
+
+use super::{LockType, PackageOptions, WorkspaceCommand};
+
+/// Perform formal verification on a program
+#[derive(Debug, Clone, Args)]
+#[clap(visible_alias = "fv")]
+pub(crate) struct FormalVerifyCommand {
+    #[clap(flatten)]
+    pub(super) package_options: PackageOptions,
+
+    // This is necessary for compiling packages
+    #[clap(flatten)]
+    compile_options: CompileOptions,
+
+    // Flags which will be propagated to the Venir binary
+    #[clap(last = true)]
+    venir_flags: Vec<String>,
+}
+
+impl WorkspaceCommand for FormalVerifyCommand {
+    fn package_selection(&self) -> PackageSelection {
+        self.package_options.package_selection()
+    }
+
+    fn lock_type(&self) -> LockType {
+        LockType::Exclusive
+    }
+}
+
+pub(crate) fn run(args: FormalVerifyCommand, workspace: Workspace) -> Result<(), CliError> {
+    todo!()
+}

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -22,6 +22,7 @@ mod execute_cmd;
 mod export_cmd;
 mod fmt_cmd;
 mod fuzz_cmd;
+mod fv_cmd;
 mod generate_completion_script_cmd;
 mod info_cmd;
 mod init_cmd;
@@ -108,6 +109,7 @@ enum NargoCommand {
     #[command(hide = true)]
     Dap(dap_cmd::DapCommand),
     GenerateCompletionScript(generate_completion_script_cmd::GenerateCompletionScriptCommand),
+    FormalVerify(fv_cmd::FormalVerifyCommand),
 }
 
 /// Commands that can execute on the workspace level, or be limited to a selected package.
@@ -150,6 +152,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
         NargoCommand::Dap(args) => dap_cmd::run(args),
         NargoCommand::Fmt(args) => with_workspace(args, config, fmt_cmd::run),
         NargoCommand::GenerateCompletionScript(args) => generate_completion_script_cmd::run(args),
+        NargoCommand::FormalVerify(args) => with_workspace(args, config, fv_cmd::run),
     }?;
 
     Ok(())


### PR DESCRIPTION
Added `nargo formal-verify` command with alias `nargo fv` to the Nargo CLI.
As of now the `run()` function is not implemented.