### PR TITLE
feat(fv): Parser for implication operator

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -1000,6 +1000,8 @@ fn convert_operator(op: BinaryOpKind) -> BinaryOp {
         BinaryOpKind::Xor => BinaryOp::Xor,
         BinaryOpKind::ShiftLeft => BinaryOp::Shl,
         BinaryOpKind::ShiftRight => BinaryOp::Shr,
+        //TODO(totel) Make sure all Implication operations are optimized away.
+        BinaryOpKind::Implication => unreachable!(),
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -1000,8 +1000,9 @@ fn convert_operator(op: BinaryOpKind) -> BinaryOp {
         BinaryOpKind::Xor => BinaryOp::Xor,
         BinaryOpKind::ShiftLeft => BinaryOp::Shl,
         BinaryOpKind::ShiftRight => BinaryOp::Shr,
-        //TODO(totel) Make sure all Implication operations are optimized away.
-        BinaryOpKind::Implication => unreachable!(),
+        BinaryOpKind::Implication => unreachable!(
+            "All implication operations `p ==> q` must have been converted to `!p | q`"
+        ),
     }
 }
 

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -323,6 +323,7 @@ pub enum BinaryOpKind {
     ShiftRight,
     ShiftLeft,
     Modulo,
+    Implication,
 }
 
 impl BinaryOpKind {
@@ -371,6 +372,7 @@ impl BinaryOpKind {
             BinaryOpKind::ShiftRight => ">>",
             BinaryOpKind::ShiftLeft => "<<",
             BinaryOpKind::Modulo => "%",
+            BinaryOpKind::Implication => "==>",
         }
     }
 
@@ -392,6 +394,7 @@ impl BinaryOpKind {
             BinaryOpKind::ShiftLeft => Token::ShiftLeft,
             BinaryOpKind::ShiftRight => Token::ShiftRight,
             BinaryOpKind::Modulo => Token::Percent,
+            BinaryOpKind::Implication => Token::Implication,
         }
     }
 }
@@ -824,6 +827,7 @@ impl Display for BinaryOpKind {
             BinaryOpKind::ShiftLeft => write!(f, "<<"),
             BinaryOpKind::ShiftRight => write!(f, ">>"),
             BinaryOpKind::Modulo => write!(f, "%"),
+            BinaryOpKind::Implication => write!(f, "==>"),
         }
     }
 }

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -518,7 +518,8 @@ impl UnresolvedTypeExpression {
                     | BinaryOpKind::Or
                     | BinaryOpKind::Xor
                     | BinaryOpKind::ShiftRight
-                    | BinaryOpKind::ShiftLeft => {
+                    | BinaryOpKind::ShiftLeft
+                    | BinaryOpKind::Implication => {
                         unreachable!("impossible via `operator_allowed` check")
                     }
                 };

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
@@ -197,5 +197,8 @@ pub(super) fn evaluate_infix(
         BinaryOpKind::Modulo => match_integer! {
             (lhs_value as lhs "%" rhs_value as rhs) => lhs.checked_rem(rhs)
         },
+        BinaryOpKind::Implication => match_bitwise! {
+            (lhs_value as lhs "==>" rhs_value as rhs) => !lhs | rhs
+        },
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -61,7 +61,7 @@ impl Parser<'_> {
     }
 
     fn parse_expression_impl(&mut self, allow_constructors: bool) -> Option<Expression> {
-        self.parse_equal_or_not_equal(allow_constructors)
+        self.parse_implication(allow_constructors)
     }
 
     /// Term
@@ -1028,15 +1028,13 @@ mod tests {
 
     use crate::{
         ast::{
-            ArrayLiteral, BinaryOpKind, ConstrainKind, Expression, ExpressionKind, Literal,
-            StatementKind, UnaryOp, UnresolvedTypeData,
+            ArrayLiteral, BinaryOpKind, ConstrainKind, Expression, ExpressionKind, Literal, StatementKind, UnaryOp, UnresolvedTypeData
         },
         parser::{
-            Parser, ParserErrorReason,
             parser::tests::{
                 expect_no_errors, get_single_error, get_single_error_reason,
                 get_source_with_error_span,
-            },
+            }, Parser, ParserErrorReason
         },
         signed_field::SignedField,
         token::Token,
@@ -2168,5 +2166,16 @@ mod tests {
 
         let reason = get_single_error_reason(&parser.errors, span);
         assert!(matches!(reason, ParserErrorReason::ConstrainDeprecated));
+    }
+
+    #[test]
+    fn parses_implication() {
+        let src = "x > 4 ==> y < 2";
+        let expr = parse_expression_no_errors(src);
+        let ExpressionKind::Infix(infix_expression) = expr.kind else {
+            panic!("Expected infix expression");
+        };
+        let operator = infix_expression.operator;
+        assert!(matches!(operator.contents, BinaryOpKind::Implication));
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/infix.rs
+++ b/compiler/noirc_frontend/src/parser/parser/infix.rs
@@ -9,6 +9,18 @@ use crate::{
 use super::Parser;
 
 impl<'a> Parser<'a> {
+    /// ImplicationExpression
+    ///     = EqualOrNotEqualExpression ( '==>' EqualOrNotEqualExpression )*
+    pub(super) fn parse_implication(&mut self, allow_constructors: bool) -> Option<Expression> {
+        self.parse_infix(allow_constructors, Parser::parse_equal_or_not_equal, |parser| {
+            if parser.eat(Token::Implication) {
+                Some(BinaryOpKind::Implication)
+            } else {
+                None
+            }
+        })
+    }
+
     /// EqualOrNotEqualExpression
     ///     = OrExpression ( ( '==' | '!=' ) OrExpression )*
     pub(super) fn parse_equal_or_not_equal(


### PR DESCRIPTION
Also expanded the AST expression structure to support implication operator. This is different than the prototype implementation where when we parsed an implication `p ==> q` we transformed it into `!p | q`.

This means that we will have to constrain its use only spec code in a
separate commit. Just the same way we will do with the quantifier expressions.

Another option is to not accept this PR and implement the parser the same way we did in the prototype. We will discuss which option is more upstream friendly. 
