### PR TITLE
feat(fv): Add semantic analysis for fv annotations

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -93,6 +93,7 @@ impl<'context> Elaborator<'context> {
             self.interpreter_call_stack.clone(),
             self.options,
             self.elaborate_reasons.clone(),
+            self.perform_formal_verification,
         );
 
         elaborator.function_context.push(FunctionContext::default());

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -257,6 +257,7 @@ impl Elaborator<'_> {
             source_module: type_id.local_module_id(),
             source_file: variant.name.location().file,
             self_type: None,
+            formal_verification_attributes: Vec::new(),
         };
 
         self.interner.push_fn_meta(meta, id);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -7,9 +7,15 @@ use crate::{
     DataType, StructField, TypeBindings,
     ast::{IntegerBitSize, ItemVisibility, UnresolvedType},
     graph::CrateGraph,
-    hir_def::traits::ResolvedTraitBound,
+    hir_def::{
+        function::ResolvedFvAttribute,
+        stmt::{HirLetStatement, HirPattern, HirStatement},
+        traits::ResolvedTraitBound,
+    },
+    lexer::fv_attributes::FormalVerificationAttribute,
     node_interner::GlobalValue,
     shared::Signedness,
+    token::Attributes,
     usage_tracker::UsageTracker,
 };
 use crate::{
@@ -202,6 +208,9 @@ pub struct Elaborator<'context> {
     /// The Elaborator keeps track of these reasons so that when an error is produced it will
     /// be wrapped in another error that will include this reason.
     pub(crate) elaborate_reasons: im::Vector<ElaborateReason>,
+
+    /// Indicates if we have to elaborate or ignore formal verification attributes.
+    perform_formal_verification: bool,
 }
 
 #[derive(Copy, Clone)]
@@ -270,6 +279,7 @@ impl<'context> Elaborator<'context> {
         interpreter_call_stack: im::Vector<Location>,
         options: ElaboratorOptions<'context>,
         elaborate_reasons: im::Vector<ElaborateReason>,
+        perform_formal_verification: bool,
     ) -> Self {
         Self {
             scopes: ScopeForest::default(),
@@ -297,6 +307,7 @@ impl<'context> Elaborator<'context> {
             silence_field_visibility_errors: 0,
             options,
             elaborate_reasons,
+            perform_formal_verification,
         }
     }
 
@@ -314,6 +325,7 @@ impl<'context> Elaborator<'context> {
             im::Vector::new(),
             options,
             im::Vector::new(),
+            context.perform_formal_verification,
         )
     }
 
@@ -431,8 +443,8 @@ impl<'context> Elaborator<'context> {
     }
 
     fn elaborate_functions(&mut self, functions: UnresolvedFunctions) {
-        for (_, id, _) in functions.functions {
-            self.elaborate_function(id);
+        for (_, id, noir_function) in functions.functions {
+            self.elaborate_function(id, Some(noir_function.attributes()));
         }
 
         self.generics.clear();
@@ -459,7 +471,7 @@ impl<'context> Elaborator<'context> {
         self.generics = all_generics;
     }
 
-    pub(crate) fn elaborate_function(&mut self, id: FuncId) {
+    pub(crate) fn elaborate_function(&mut self, id: FuncId, attributes: Option<&Attributes>) {
         let func_meta = self.interner.func_meta.get_mut(&id);
         let func_meta =
             func_meta.expect("FuncMetas should be declared before a function is elaborated");
@@ -546,7 +558,29 @@ impl<'context> Elaborator<'context> {
 
         // Don't verify the return type for builtin functions & trait function declarations
         if !func_meta.is_stub() {
-            self.type_check_function_body(body_type, &func_meta, hir_func.as_expr());
+            self.type_check_function_body(body_type.clone(), &func_meta, hir_func.as_expr());
+        }
+
+        if let Some(attributes_inner) = attributes {
+            if !attributes_inner.secondary.is_empty() && self.perform_formal_verification {
+                self.elaborate_fv_attributes(
+                    attributes_inner
+                        .secondary
+                        .iter()
+                        .filter_map(|attribute| {
+                            if let SecondaryAttribute::FvAttribute(fv_attribute) = attribute {
+                                Some(fv_attribute)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect(),
+                    id,
+                    body_type,
+                    &hir_func,
+                    func_meta.location,
+                );
+            }
         }
 
         // Default any type variables that still need defaulting and
@@ -1077,6 +1111,7 @@ impl<'context> Elaborator<'context> {
             function_body: FunctionBody::Unresolved(func.kind, body, func.def.location),
             self_type: self.self_type.clone(),
             source_file: location.file,
+            formal_verification_attributes: Vec::new(),
         };
 
         self.interner.push_fn_meta(meta, func_id);
@@ -2262,6 +2297,105 @@ impl<'context> Elaborator<'context> {
         let ret = f(self);
         let errored = self.errors.iter().skip(previous_errors).any(|error| error.is_error());
         (errored, ret)
+    }
+
+    /// Performs semantic analysis on the formal verification attributes discovered by the parser.
+    ///
+    /// # Arguments
+    ///
+    /// * `fv_attributes` - the parsed attributes
+    /// * `func_id` - this is the `FuncId` of the function to which the attributes are attached
+    /// * `body_type` - this is the semantically inferred type of the expression that is the body of the function
+    /// * `hir_func` - this identifies the same expression
+    /// * `func_span` - represents the span in code
+    fn elaborate_fv_attributes(
+        &mut self,
+        fv_attributes: Vec<&FormalVerificationAttribute>,
+        func_id: FuncId,
+        body_type: Type,
+        hir_func: &HirFunction,
+        func_location: Location,
+    ) {
+        for attribute in fv_attributes {
+            match attribute {
+                FormalVerificationAttribute::Ensures(ensures_attribute) => {
+                    self.add_result_variable_to_scope(body_type.clone(), hir_func, func_location);
+                    let expr_location = ensures_attribute.location;
+                    // Type inference happens here:
+                    let (expr_id, typ) = self.elaborate_expression(ensures_attribute.body.clone());
+                    // Type checking happens here:
+                    self.unify_with_coercions(&typ, &Type::Bool, expr_id, expr_location, || {
+                        TypeCheckError::TypeMismatch {
+                            expected_typ: Type::Bool.to_string(),
+                            expr_typ: typ.to_string(),
+                            expr_location,
+                        }
+                    });
+                    // Saving the attributes in the function metadata:
+                    self.interner
+                        .function_meta_mut(&func_id)
+                        .formal_verification_attributes
+                        .push(ResolvedFvAttribute::Ensures(expr_id));
+                }
+
+                FormalVerificationAttribute::Requires(requires_attribute) => {
+                    let expr_location = requires_attribute.location;
+                    let (expr_id, typ) = self.elaborate_expression(requires_attribute.body.clone());
+                    self.unify_with_coercions(&typ, &Type::Bool, expr_id, expr_location, || {
+                        TypeCheckError::TypeMismatch {
+                            expected_typ: Type::Bool.to_string(),
+                            expr_typ: typ.to_string(),
+                            expr_location,
+                        }
+                    });
+                    self.interner
+                        .function_meta_mut(&func_id)
+                        .formal_verification_attributes
+                        .push(ResolvedFvAttribute::Requires(expr_id));
+                }
+
+                FormalVerificationAttribute::Ghost => {
+                    self.interner
+                        .function_meta_mut(&func_id)
+                        .formal_verification_attributes
+                        .push(ResolvedFvAttribute::Ghost);
+                }
+            }
+        }
+    }
+
+    /// Adds the function's return value to the variable scope with
+    /// identifier `result`. This is required because the `ensures` formal
+    /// verification attribute should be able to make statements about
+    /// the function's return value.
+    fn add_result_variable_to_scope(
+        &mut self,
+        body_type: Type,
+        hir_func: &HirFunction,
+        func_location: Location,
+    ) {
+        let result_hir_ident = self.add_variable_decl(
+            Ident::new(String::from("result"), func_location),
+            false,
+            true,
+            false,
+            DefinitionKind::Local(Some(hir_func.as_expr())),
+        );
+
+        self.interner.push_definition_type(result_hir_ident.id, body_type.clone());
+
+        let result_hir_pattern = HirPattern::Identifier(result_hir_ident);
+        let hir_statement = HirStatement::Let(HirLetStatement {
+            pattern: result_hir_pattern,
+            r#type: body_type.clone(),
+            expression: hir_func.as_expr(),
+            attributes: Vec::new(),
+            comptime: false,
+            is_global_let: false,
+        });
+        let id = self.interner.push_stmt(hir_statement);
+
+        self.interner.push_stmt_location(id, func_location);
     }
 }
 

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -241,7 +241,7 @@ impl Elaborator<'_> {
         // Here we elaborate functions without a body, mainly to check the arguments and return types.
         // Later on we'll elaborate functions with a body by fully type-checking them.
         if !has_body {
-            self.elaborate_function(func_id);
+            self.elaborate_function(func_id, Some(function.attributes()));
         }
 
         let _ = self.scopes.end_function();

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -193,7 +193,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             None => {
                 if matches!(&meta.function_body, FunctionBody::Unresolved(..)) {
                     self.elaborate_in_function(None, None, |elaborator| {
-                        elaborator.elaborate_function(function);
+                        elaborator.elaborate_function(function, None);
                     });
 
                     self.get_function_body(function, location)

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -168,6 +168,9 @@ pub struct FuncMeta {
     /// If this function is from an impl (trait or regular impl), this
     /// is the object type of the impl. Otherwise this is None.
     pub self_type: Option<Type>,
+
+    /// Formal verification attributes attached to this function.
+    pub formal_verification_attributes: Vec<ResolvedFvAttribute>,
 }
 
 #[derive(Debug, Clone)]
@@ -175,6 +178,13 @@ pub enum FunctionBody {
     Unresolved(FunctionKind, BlockExpression, Location),
     Resolving,
     Resolved,
+}
+
+#[derive(Debug, Clone)]
+pub enum ResolvedFvAttribute {
+    Ensures(ExprId),
+    Requires(ExprId),
+    Ghost,
 }
 
 impl FuncMeta {


### PR DESCRIPTION
Added name resolution and type checking for the expression bodies of the formal verification attributes. This means that functions in HIR now have resolved formal verification attributes attached to them.

Also disabled semantic analysis of fv annotations in all `nargo` cli commands except when you run `nargo fv`. This means that you will get errors about incorrect fv annotations expressions only when you run `nargo fv`.
