### PR TITLE
test(fv): Expand testing logic

### DIFF
--- a/test_programs/formal_verify_failure/fv_attribute_name_resolution_1/Nargo.toml
+++ b/test_programs/formal_verify_failure/fv_attribute_name_resolution_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/fv_attribute_name_resolution_1/src/main.nr
+++ b/test_programs/formal_verify_failure/fv_attribute_name_resolution_1/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[requires(y > 5)]
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/formal_verify_failure/fv_attribute_name_resolution_2/Nargo.toml
+++ b/test_programs/formal_verify_failure/fv_attribute_name_resolution_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/fv_attribute_name_resolution_2/src/main.nr
+++ b/test_programs/formal_verify_failure/fv_attribute_name_resolution_2/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[requires(result > 5)]  // result can be only used in the ensures attribute
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/formal_verify_failure/fv_attribute_name_resolution_3/Nargo.toml
+++ b/test_programs/formal_verify_failure/fv_attribute_name_resolution_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/fv_attribute_name_resolution_3/src/main.nr
+++ b/test_programs/formal_verify_failure/fv_attribute_name_resolution_3/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[ensures(result > y)]
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/formal_verify_failure/fv_attribute_type_check_1/Nargo.toml
+++ b/test_programs/formal_verify_failure/fv_attribute_type_check_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/fv_attribute_type_check_1/src/main.nr
+++ b/test_programs/formal_verify_failure/fv_attribute_type_check_1/src/main.nr
@@ -1,0 +1,9 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[requires(x)]
+fn foo(x: Field) -> Field {
+  x + x
+}
+

--- a/test_programs/formal_verify_failure/fv_attribute_type_check_2/Nargo.toml
+++ b/test_programs/formal_verify_failure/fv_attribute_type_check_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/fv_attribute_type_check_2/src/main.nr
+++ b/test_programs/formal_verify_failure/fv_attribute_type_check_2/src/main.nr
@@ -1,0 +1,9 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[ensures(result)]
+fn foo(x: Field) -> Field {
+  x + x
+}
+

--- a/test_programs/formal_verify_failure/fv_attribute_type_check_3/Nargo.toml
+++ b/test_programs/formal_verify_failure/fv_attribute_type_check_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_failure/fv_attribute_type_check_3/src/main.nr
+++ b/test_programs/formal_verify_failure/fv_attribute_type_check_3/src/main.nr
@@ -1,0 +1,9 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[requires(5)]
+fn foo(x: Field) -> Field {
+  x + x
+}
+

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -41,6 +42,8 @@ fn main() {
     generate_compile_success_with_bug_tests(&mut test_file, &test_dir);
     generate_compile_failure_tests(&mut test_file, &test_dir);
     generate_fuzzing_failure_tests(&mut test_file, &test_dir);
+    generate_formal_verify_success_tests(&mut test_file, &test_dir);
+    generate_formal_verify_failure_tests(&mut test_file, &test_dir);
 }
 
 /// Some tests are explicitly ignored in brillig due to them failing.
@@ -539,4 +542,81 @@ fn generate_compile_failure_tests(test_file: &mut File, test_data_dir: &Path) {
         );
     }
     writeln!(test_file, "}}").unwrap();
+}
+
+/// Tests which must succeed after undergoing formal verification.
+fn generate_formal_verify_success_tests(test_file: &mut File, test_data_dir: &Path) {
+    let test_type = "formal_verify_success";
+    let test_cases = read_test_cases(test_data_dir, test_type);
+    for (test_name, test_dir) in test_cases {
+        write!(
+            test_file,
+            r#"
+#[test]
+fn formal_verify_success_{test_name}() {{
+    let test_program_dir = PathBuf::from("{test_dir}");
+
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("--program-dir").arg(test_program_dir);
+    cmd.arg("formal-verify");
+
+    cmd.assert().success();
+}}
+            "#,
+            test_dir = test_dir.display(),
+        )
+        .expect("Could not write templated test file.");
+    }
+}
+
+/// Tests which must fail during formal verification.
+fn generate_formal_verify_failure_tests(test_file: &mut File, test_data_dir: &Path) {
+    let test_type = "formal_verify_failure";
+    let test_cases = read_test_cases(test_data_dir, test_type);
+
+    let expected_messages = HashMap::from([("simple_add", vec!["Cannot satisfy constraint"])]);
+
+    for (test_name, test_dir) in test_cases {
+        write!(
+            test_file,
+            r#"
+#[test]
+fn formal_verify_failure_{test_name}() {{
+    let test_program_dir = PathBuf::from("{test_dir}");
+
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("--program-dir").arg(test_program_dir);
+    cmd.arg("formal-verify");
+
+    cmd.assert().failure().stderr(
+        predicate::str::contains("The application panicked (crashed).")
+        .or(predicate::str::contains("error:")),
+    );"#,
+            test_dir = test_dir.display(),
+        )
+        .expect("Could not write templated test file.");
+
+        // Not all tests have expected messages, so match.
+        match expected_messages.get(test_name.as_str()) {
+            Some(messages) => {
+                for message in messages.iter() {
+                    write!(
+                        test_file,
+                        r#"
+    cmd.assert().failure().stderr(predicate::str::contains("{message}"));"#
+                    )
+                    .expect("Could not write templated test file.");
+                }
+            }
+            None => {}
+        }
+
+        write!(
+            test_file,
+            r#"
+}}
+"#
+        )
+        .expect("Could not write templated test file.");
+    }
 }


### PR DESCRIPTION
Now there are two directories for testing formal verification functionality. Them being `formal_verify_failure` and `formal_verify_success`.

Added some tests which check if the semantic analysis of fv annotation expressions is correct.
