### PR TITLE
feat(fv): Semantic analysis for quantifiers

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -10,8 +10,8 @@ use crate::{
         ConstrainExpression, ConstrainKind, ConstructorExpression, Expression, ExpressionKind,
         Ident, IfExpression, IndexExpression, InfixExpression, ItemVisibility, Lambda, Literal,
         MatchExpression, MemberAccessExpression, MethodCallExpression, Path, PathSegment,
-        PrefixExpression, StatementKind, TraitBound, UnaryOp, UnresolvedTraitConstraint,
-        UnresolvedTypeData, UnresolvedTypeExpression, UnsafeExpression,
+        PrefixExpression, QuantifierExpression, StatementKind, TraitBound, UnaryOp,
+        UnresolvedTraitConstraint, UnresolvedTypeData, UnresolvedTypeExpression, UnsafeExpression,
     },
     hir::{
         comptime::{self, InterpreterError},
@@ -26,8 +26,8 @@ use crate::{
             HirArrayLiteral, HirBinaryOp, HirBlockExpression, HirCallExpression, HirCastExpression,
             HirConstrainExpression, HirConstructorExpression, HirExpression, HirIdent,
             HirIfExpression, HirIndexExpression, HirInfixExpression, HirLambda, HirLiteral,
-            HirMatch, HirMemberAccess, HirMethodCallExpression, HirPrefixExpression, ImplKind,
-            TraitMethod,
+            HirMatch, HirMemberAccess, HirMethodCallExpression, HirPrefixExpression,
+            HirQuantifierExpression, ImplKind, TraitMethod,
         },
         stmt::{HirLetStatement, HirPattern, HirStatement},
         traits::{ResolvedTraitBound, TraitConstraint},
@@ -99,7 +99,9 @@ impl Elaborator<'_> {
                 return self.elaborate_as_trait_path(path);
             }
             ExpressionKind::TypePath(path) => return self.elaborate_type_path(path),
-            ExpressionKind::Quantifier(_) => todo!(), // TODO(totel)
+            ExpressionKind::Quantifier(quantifier_expression) => {
+                self.elaborate_quantifier(*quantifier_expression, expr.location)
+            }
         };
         let id = self.interner.push_expr(hir_expr);
         self.interner.push_expr_location(id, expr.location);
@@ -1415,5 +1417,55 @@ impl Elaborator<'_> {
         let typ = self.type_check_variable(ident, id, None);
         self.interner.push_expr_type(id, typ.clone());
         (id, typ)
+    }
+
+    pub(super) fn elaborate_quantifier(
+        &mut self,
+        quantifier_expression: QuantifierExpression,
+        location: Location,
+    ) -> (HirExpression, Type) {
+        if !self.in_specification_context {
+            self.push_err(ResolverError::QuantifierInExecCode { location });
+            return (HirExpression::Error, Type::Bool);
+        }
+
+        self.push_scope();
+        let QuantifierExpression { quantifier_type, indexes, body } = quantifier_expression;
+        let indexes_as_pattern: Vec<HirPattern> = indexes
+            .into_iter()
+            .map(|ident| {
+                HirPattern::Identifier({
+                    let hir_ident = self.add_variable_decl(
+                        ident,
+                        false,
+                        true,
+                        true,
+                        DefinitionKind::Local(None),
+                    );
+
+                    let type_var_id = self.interner.next_type_variable_id();
+                    let type_variable = Type::type_variable(type_var_id);
+                    self.interner.push_definition_type(hir_ident.id, type_variable);
+                    hir_ident
+                })
+            })
+            .collect();
+
+        let (body_expr_id, body_expr_type) = self.elaborate_expression(body);
+
+        self.unify(&body_expr_type, &Type::Bool, || TypeCheckError::TypeMismatch {
+            expected_typ: Type::Bool.to_string(),
+            expr_typ: body_expr_type.to_string(),
+            expr_location: location,
+        });
+
+        let hir_quantifier = HirExpression::Quantifier(HirQuantifierExpression {
+            quantifier_type,
+            indexes: indexes_as_pattern,
+            body: body_expr_id,
+        });
+
+        self.pop_scope();
+        (hir_quantifier, Type::Bool)
     }
 }

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -316,7 +316,7 @@ fn can_return_without_recursing(interner: &NodeInterner, func_id: FuncId, expr_i
         HirExpression::Match(e) => can_return_without_recursing_match(interner, func_id, &e),
         HirExpression::Tuple(e) => e.iter().cloned().all(check),
         HirExpression::Unsafe(b) => check_block(b),
-        // Rust doesn't check the lambda body (it might not be called).
+        HirExpression::Quantifier(q) => check(q.body),
         HirExpression::Lambda(_)
         | HirExpression::Literal(_)
         | HirExpression::Constructor(_)

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -211,6 +211,10 @@ pub struct Elaborator<'context> {
 
     /// Indicates if we have to elaborate or ignore formal verification attributes.
     perform_formal_verification: bool,
+
+    /// True if we're elaborating the body of a formal verification annotation.
+    /// This is needed because we want to allow certain expressions only in fv specification code.
+    in_specification_context: bool,
 }
 
 #[derive(Copy, Clone)]
@@ -308,6 +312,7 @@ impl<'context> Elaborator<'context> {
             options,
             elaborate_reasons,
             perform_formal_verification,
+            in_specification_context: false,
         }
     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -149,6 +149,9 @@ pub enum InterpreterError {
     UnquoteFoundDuringEvaluation {
         location: Location,
     },
+    QuantifierFoundDuringEvaluation {
+        location: Location,
+    },
     DebugEvaluateComptime {
         diagnostic: CustomDiagnostic,
         location: Location,
@@ -306,6 +309,7 @@ impl InterpreterError {
             | InterpreterError::NonEnumInConstructor { location, .. }
             | InterpreterError::CannotInlineMacro { location, .. }
             | InterpreterError::UnquoteFoundDuringEvaluation { location, .. }
+            | InterpreterError::QuantifierFoundDuringEvaluation { location, .. }
             | InterpreterError::UnsupportedTopLevelItemUnquote { location, .. }
             | InterpreterError::ComptimeDependencyCycle { location, .. }
             | InterpreterError::Unimplemented { location, .. }
@@ -520,6 +524,11 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             InterpreterError::UnquoteFoundDuringEvaluation { location } => {
                 let msg = "Unquote found during comptime evaluation".into();
                 let secondary = "This is a bug".into();
+                CustomDiagnostic::simple_error(msg, secondary, *location)
+            }
+            InterpreterError::QuantifierFoundDuringEvaluation { location } => {
+                let msg = "Quantifier found during comptime evaluation".into();
+                let secondary = "Quantifiers are allowed only in specification code".into();
                 CustomDiagnostic::simple_error(msg, secondary, *location)
             }
             InterpreterError::DebugEvaluateComptime { diagnostic, .. } => diagnostic.clone(),

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -6,12 +6,13 @@ use crate::ast::{
     ArrayLiteral, AssignStatement, BlockExpression, CallExpression, CastExpression, ConstrainKind,
     ConstructorExpression, ExpressionKind, ForLoopStatement, ForRange, GenericTypeArgs, Ident,
     IfExpression, IndexExpression, InfixExpression, LValue, Lambda, Literal, MatchExpression,
-    MemberAccessExpression, Path, PathSegment, Pattern, PrefixExpression, UnresolvedType,
-    UnresolvedTypeData, UnresolvedTypeExpression, UnsafeExpression, WhileStatement,
+    MemberAccessExpression, Path, PathSegment, Pattern, PrefixExpression, QuantifierExpression,
+    UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression, UnsafeExpression, WhileStatement,
 };
 use crate::ast::{ConstrainExpression, Expression, Statement, StatementKind};
 use crate::hir_def::expr::{
-    Constructor, HirArrayLiteral, HirBlockExpression, HirExpression, HirIdent, HirLiteral, HirMatch,
+    Constructor, HirArrayLiteral, HirBlockExpression, HirExpression, HirIdent, HirLiteral,
+    HirMatch, HirQuantifierExpression,
 };
 use crate::hir_def::stmt::{HirLValue, HirPattern, HirStatement};
 use crate::hir_def::types::{Type, TypeBinding};
@@ -206,6 +207,19 @@ impl HirExpression {
                 let arguments = vecmap(&constructor.arguments, |arg| arg.to_display_ast(interner));
                 let call = CallExpression { func, arguments, is_macro_call: false };
                 ExpressionKind::Call(Box::new(call))
+            }
+            HirExpression::Quantifier(hir_quantifier_expression) => {
+                let HirQuantifierExpression { quantifier_type, indexes, body } =
+                    hir_quantifier_expression;
+                let idents: Vec<Ident> = indexes
+                    .iter()
+                    .map(|ident| ident.to_display_ast(interner).name_ident().to_owned())
+                    .collect();
+                ExpressionKind::Quantifier(Box::new(QuantifierExpression {
+                    quantifier_type: quantifier_type.clone(),
+                    indexes: idents,
+                    body: body.to_display_ast(interner),
+                }))
             }
         };
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -546,6 +546,10 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 let location = self.elaborator.interner.expr_location(&id);
                 Err(InterpreterError::UnquoteFoundDuringEvaluation { location })
             }
+            HirExpression::Quantifier(quantifier) => {
+                let location = self.elaborator.interner.expr_location(&id);
+                Err(InterpreterError::QuantifierFoundDuringEvaluation { location })
+            }
             HirExpression::Error => {
                 let location = self.elaborator.interner.expr_location(&id);
                 Err(InterpreterError::ErrorNodeEncountered { location })

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -200,6 +200,8 @@ pub enum ResolverError {
         "The type parameter `{ident}` is not constrained by the impl trait, self type, or predicates"
     )]
     UnconstrainedTypeParameter { ident: Ident },
+    #[error("Quantifiers `forall` and `exists` cannot be used in exec code")]
+    QuantifierInExecCode {location: Location},
 }
 
 impl ResolverError {
@@ -264,7 +266,8 @@ impl ResolverError {
             | ResolverError::UnexpectedItemInPattern { location, .. }
             | ResolverError::NoSuchMethodInTrait { location, .. }
             | ResolverError::VariableAlreadyDefinedInPattern { new_location: location, .. }
-            | ResolverError::NonU32Index { location } => *location,
+            | ResolverError::NonU32Index { location }
+            | ResolverError::QuantifierInExecCode { location } => *location,
             ResolverError::UnusedVariable { ident }
             | ResolverError::UnusedItem { ident, .. }
             | ResolverError::DuplicateField { field: ident }
@@ -823,6 +826,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                     ident.location(),
                 )
             }
+            ResolverError::QuantifierInExecCode { location } => {
+                Diagnostic::simple_error(
+                    "Quantifiers cannot be used in exec code".to_string(),
+                    "They can only be used `ensures` and `requires` annotations".to_string(),
+                    *location,
+                )
+            },
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -3,7 +3,7 @@ use iter_extended::vecmap;
 use noirc_errors::Location;
 
 use crate::Shared;
-use crate::ast::{BinaryOp, BinaryOpKind, Ident, UnaryOp};
+use crate::ast::{BinaryOp, BinaryOpKind, Ident, QuantifierType, UnaryOp};
 use crate::hir::type_check::generics::TraitGenerics;
 use crate::node_interner::{
     DefinitionId, DefinitionKind, ExprId, FuncId, NodeInterner, StmtId, TraitMethodId,
@@ -43,6 +43,7 @@ pub enum HirExpression {
     Quote(Tokens),
     Unquote(Tokens),
     Unsafe(HirBlockExpression),
+    Quantifier(HirQuantifierExpression),
     Error,
 }
 
@@ -497,4 +498,11 @@ impl std::fmt::Display for Constructor {
             Constructor::Range(start, end) => write!(f, "{start} .. {end}"),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct HirQuantifierExpression {
+    pub quantifier_type: QuantifierType,
+    pub indexes: Vec<HirPattern>,
+    pub body: ExprId,
 }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -615,6 +615,7 @@ impl<'interner> Monomorphizer<'interner> {
             HirExpression::EnumConstructor(constructor) => {
                 self.enum_constructor(constructor, expr)?
             }
+            HirExpression::Quantifier(_) => todo!(), //TODO(totel)
         };
 
         Ok(expr)


### PR DESCRIPTION
Added type checking and name resolution for quantifier expressions. This happens during the elaboration phase in the Noir compiler.

Because of a limitation of the Noir type system we initialize the quantifier indexes with type `Unbounded(Any)`. Those types automatically bound themseleves to the first type they interact with. In result the user sometimes has to do some extra type casting when using indexes.
