### PR TITLE
feat(fv): Semantic analysis for implication operator

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -1000,9 +1000,7 @@ fn convert_operator(op: BinaryOpKind) -> BinaryOp {
         BinaryOpKind::Xor => BinaryOp::Xor,
         BinaryOpKind::ShiftLeft => BinaryOp::Shl,
         BinaryOpKind::ShiftRight => BinaryOp::Shr,
-        BinaryOpKind::Implication => unreachable!(
-            "All implication operations `p ==> q` must have been converted to `!p | q`"
-        ),
+        BinaryOpKind::Implication => BinaryOp::Or, // `p ==> q` is being converted to `!p | q`
     }
 }
 

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -342,6 +342,10 @@ impl BinaryOpKind {
         )
     }
 
+    pub fn is_implication(self) -> bool {
+        matches!(self, BinaryOpKind::Implication)
+    }
+
     pub fn is_valid_for_field_type(self) -> bool {
         matches!(
             self,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1164,6 +1164,10 @@ impl Elaborator<'_> {
             return self.comparator_operand_type_rules(lhs_type, rhs_type, op, location);
         }
 
+        if op.kind.is_implication() {
+            return self.implication_type_rules(lhs_type, rhs_type, op, location);
+        }
+
         use Type::*;
         match (lhs_type, rhs_type) {
             // An error type on either side will always return an error
@@ -2128,6 +2132,40 @@ impl Elaborator<'_> {
 
     pub(crate) fn fully_qualified_trait_path(&self, trait_: &Trait) -> String {
         fully_qualified_module_path(self.def_maps, self.crate_graph, &trait_.crate_id, trait_.id.0)
+    }
+
+    fn implication_type_rules(
+        &mut self,
+        lhs_type: &Type,
+        rhs_type: &Type,
+        op: &HirBinaryOp,
+        location: Location,
+    ) -> Result<(Type, bool), TypeCheckError> {
+        use Type::*;
+
+        match (lhs_type, rhs_type) {
+            // Avoid reporting errors multiple times
+            (Error, _) | (_, Error) => Ok((Bool, false)),
+            (Alias(alias, args), other) | (other, Alias(alias, args)) => {
+                let alias = alias.borrow().get_type(args);
+                self.implication_type_rules(&alias, other, op, location)
+            }
+
+            // Matches on TypeVariable must be first to follow any type
+            // bindings.
+            (TypeVariable(var), other) | (other, TypeVariable(var)) => {
+                if let TypeBinding::Bound(binding) = &*var.borrow() {
+                    return self.implication_type_rules(other, binding, op, location);
+                }
+
+                let use_impl = self.bind_type_variables_for_infix(lhs_type, op, rhs_type, location);
+                Ok((Bool, use_impl))
+            }
+            // The only allowed types for the implication operator
+            (Bool, Bool) => Ok((Bool, false)),
+
+            (_, _) => Err(TypeCheckError::ImplicationTypeMismatch { location }),
+        }
     }
 }
 

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -249,6 +249,8 @@ pub enum TypeCheckError {
     /// This error is used for types like integers which have too many variants to enumerate
     #[error("Missing cases: `{typ}` is non-empty")]
     MissingManyCases { typ: String, location: Location },
+    #[error("The implication operator can be used only with boolean types")]
+    ImplicationTypeMismatch { location: Location },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -340,7 +342,8 @@ impl TypeCheckError {
             | TypeCheckError::UnreachableCase { location }
             | TypeCheckError::MissingCases { location, .. }
             | TypeCheckError::MissingManyCases { location, .. }
-            | TypeCheckError::NestedUnsafeBlock { location } => *location,
+            | TypeCheckError::NestedUnsafeBlock { location }
+            | TypeCheckError::ImplicationTypeMismatch { location } => *location,
 
             TypeCheckError::DuplicateNamedTypeArg { name: ident, .. }
             | TypeCheckError::NoSuchNamedTypeArg { name: ident, .. } => ident.location(),
@@ -520,7 +523,8 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             | TypeCheckError::NonConstantEvaluated { location, .. }
             | TypeCheckError::NonConstantSliceLength { location }
             | TypeCheckError::StringIndexAssign { location }
-            | TypeCheckError::InvalidShiftSize { location } => {
+            | TypeCheckError::InvalidShiftSize { location }
+            | TypeCheckError::ImplicationTypeMismatch { location } => {
                 Diagnostic::simple_error(error.to_string(), String::new(), *location)
             }
             TypeCheckError::MutableCaptureWithoutRef { name, location } => Diagnostic::simple_error(

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1913,10 +1913,6 @@ impl NodeInterner {
     /// `self.infix_operator_traits` is expected to be filled before name resolution,
     /// during definition collection.
     pub fn get_operator_trait_method(&self, operator: BinaryOpKind) -> TraitMethodId {
-        // Return a dummy id for the implication's trait method.
-        if let BinaryOpKind::Implication = operator {
-            return TraitMethodId { trait_id: TraitId(ModuleId::dummy_id()), method_index: 0 };
-        }
         let trait_id = self.infix_operator_traits[&operator];
 
         // Assume that the operator's method to be overloaded is the first method of the trait.
@@ -1952,6 +1948,7 @@ impl NodeInterner {
             "BitXor" => BinaryOpKind::Xor,
             "Shl" => BinaryOpKind::ShiftLeft,
             "Shr" => BinaryOpKind::ShiftRight,
+            "Implication" => BinaryOpKind::Implication,
             _ => return,
         };
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1913,6 +1913,10 @@ impl NodeInterner {
     /// `self.infix_operator_traits` is expected to be filled before name resolution,
     /// during definition collection.
     pub fn get_operator_trait_method(&self, operator: BinaryOpKind) -> TraitMethodId {
+        // Return a dummy id for the implication's trait method.
+        if let BinaryOpKind::Implication = operator {
+            return TraitMethodId { trait_id: TraitId(ModuleId::dummy_id()), method_index: 0 };
+        }
         let trait_id = self.infix_operator_traits[&operator];
 
         // Assume that the operator's method to be overloaded is the first method of the trait.
@@ -2016,6 +2020,7 @@ impl NodeInterner {
         self.infix_operator_traits.insert(BinaryOpKind::Xor, dummy_trait);
         self.infix_operator_traits.insert(BinaryOpKind::ShiftLeft, dummy_trait);
         self.infix_operator_traits.insert(BinaryOpKind::ShiftRight, dummy_trait);
+        self.infix_operator_traits.insert(BinaryOpKind::Implication, dummy_trait);
         self.prefix_operator_traits.insert(UnaryOp::Minus, dummy_trait);
         self.prefix_operator_traits.insert(UnaryOp::Not, dummy_trait);
     }

--- a/noir_stdlib/src/ops/bit.nr
+++ b/noir_stdlib/src/ops/bit.nr
@@ -371,3 +371,13 @@ impl Shr for i64 {
         self >> other
     }
 }
+
+pub trait Implication {
+    fn implies(self, other: Self) -> Self;
+}
+
+impl Implication for bool {
+    fn implies(self, other: bool) -> bool {
+        self ==> other
+    }
+}


### PR DESCRIPTION
Added special type checking for the implication operator. Both lhs and rhs must be of type bool.
During the SSA gen phase the implication operation `p ==> q` is being transformed to `!p | q`.
