### PR TITLE
chore(vir): Lock vir dependency version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "air"
 version = "0.1.0"
-source = "git+https://github.com/Aristotelis2002/verus-lib#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
+source = "git+https://github.com/Aristotelis2002/verus-lib?rev=4c9858f316f6ba6016dc7ba1f1b758879cfc6897#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
 dependencies = [
  "getopts",
  "indexmap 1.9.3",
@@ -5762,7 +5762,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vir"
 version = "0.1.0"
-source = "git+https://github.com/Aristotelis2002/verus-lib#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
+source = "git+https://github.com/Aristotelis2002/verus-lib?rev=4c9858f316f6ba6016dc7ba1f1b758879cfc6897#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
 dependencies = [
  "air",
  "im",
@@ -5778,7 +5778,7 @@ dependencies = [
 [[package]]
 name = "vir-macros"
 version = "0.1.0"
-source = "git+https://github.com/Aristotelis2002/verus-lib#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
+source = "git+https://github.com/Aristotelis2002/verus-lib?rev=4c9858f316f6ba6016dc7ba1f1b758879cfc6897#4c9858f316f6ba6016dc7ba1f1b758879cfc6897"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ chumsky = { git = "https://github.com/jfecher/chumsky", rev = "ad9d312", default
 ] }
 
 # Formal verification
-vir = {git = "https://github.com/Aristotelis2002/verus-lib"}
+vir = {git = "https://github.com/Aristotelis2002/verus-lib", rev = "4c9858f316f6ba6016dc7ba1f1b758879cfc6897"}
 
 # Benchmarking
 criterion = "0.5.0"


### PR DESCRIPTION
The verus-lib dependency will have major changes to it. Therefore we want to lock onto the last stable version.
