### PR TITLE
feat(ast-to-vir): Minimal implementation for mapping AST to VIR 

### DIFF
--- a/compiler/noirc_evaluator/src/vir/vir_gen/attribute.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/attribute.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use noirc_frontend::monomorphization::ast::Function;
 use vir::ast::Exprs;
 
 pub fn func_requires_to_vir_expr(func: &Function) -> Exprs {
-    todo!()
+    Arc::new(Vec::new()) //TODO(totel)
 }
 
 pub fn func_ensures_to_vir_expr(func: &Function) -> Exprs {
-    todo!()
+    Arc::new(Vec::new()) //TODO(totel)
 }

--- a/compiler/noirc_evaluator/src/vir/vir_gen/attribute.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/attribute.rs
@@ -1,10 +1,10 @@
 use noirc_frontend::monomorphization::ast::Function;
 use vir::ast::Exprs;
 
-pub(crate) fn func_requires_to_vir_expr(func: &Function) -> Exprs {
+pub fn func_requires_to_vir_expr(func: &Function) -> Exprs {
     todo!()
 }
 
-pub(crate) fn func_ensures_to_vir_expr(func: &Function) -> Exprs {
+pub fn func_ensures_to_vir_expr(func: &Function) -> Exprs {
     todo!()
 }

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/expr.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/expr.rs
@@ -24,7 +24,7 @@ use super::types::{ast_type_to_vir_type, make_unit_vir_type};
 pub fn func_body_to_vir_expr(function: &Function, mode: Mode) -> Expr {
     let vir_expr = ast_expr_to_vir_expr(&function.body, mode);
 
-    todo!()
+    vir_expr
 }
 
 pub fn ast_expr_to_vir_expr(expr: &Expression, mode: Mode) -> Expr {

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/expr.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/expr.rs
@@ -1,6 +1,6 @@
 use noirc_frontend::monomorphization::ast::Function;
 use vir::ast::Expr;
 
-pub(crate) fn func_body_to_vir_expr(func: &Function) -> Expr {
+pub fn func_body_to_vir_expr(func: &Function) -> Expr {
     todo!()
 }

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/expr.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/expr.rs
@@ -1,6 +1,178 @@
-use noirc_frontend::monomorphization::ast::Function;
-use vir::ast::Expr;
+use std::sync::Arc;
 
-pub fn func_body_to_vir_expr(func: &Function) -> Expr {
+use crate::vir::vir_gen::{build_span, build_span_no_id, expr_to_vir::types::get_bit_not_bitwidth};
+use noirc_frontend::{
+    ast::UnaryOp,
+    monomorphization::ast::{Expression, Function, Ident, Literal, Type, Unary},
+    signed_field::SignedField,
+};
+use num_bigint::{BigInt, BigUint};
+use vir::ast::UnaryOp as VirUnaryOp;
+use vir::{
+    ast::{
+        Constant, Dt, Expr, ExprX, Mode, PatternX, SpannedTyped, Stmt, StmtX, TypX, VarIdent,
+        VarIdentDisambiguate,
+    },
+    def::Spanned,
+};
+
+use super::types::{ast_type_to_vir_type, make_unit_vir_type};
+
+pub fn func_body_to_vir_expr(function: &Function, mode: Mode) -> Expr {
+    let vir_expr = ast_expr_to_vir_expr(&function.body, mode);
+
     todo!()
+}
+
+pub fn ast_expr_to_vir_expr(expr: &Expression, mode: Mode) -> Expr {
+    match expr {
+        Expression::Ident(ident) => ast_ident_to_vir_expr(ident),
+        Expression::Literal(literal) => ast_literal_to_vir_expr(literal),
+        Expression::Block(expressions) => ast_block_to_vir_expr(expressions, mode),
+        Expression::Unary(unary) => ast_unary_to_vir_expr(unary, mode),
+        Expression::Binary(binary) => todo!(),
+        Expression::Index(index) => todo!(),
+        Expression::Cast(cast) => todo!(),
+        Expression::For(_) => todo!(),
+        Expression::Loop(expression) => todo!(),
+        Expression::While(_) => todo!(),
+        Expression::If(_) => todo!(),
+        Expression::Match(_) => todo!(),
+        Expression::Tuple(expressions) => todo!(),
+        Expression::ExtractTupleField(expression, _) => todo!(),
+        Expression::Call(call) => todo!(),
+        Expression::Let(let_expr) => todo!(),
+        Expression::Constrain(expression, location, _) => todo!(),
+        Expression::Assign(assign) => todo!(),
+        Expression::Semi(expression) => todo!(),
+        Expression::Clone(expression) => todo!(),
+        Expression::Drop(expression) => todo!(),
+        Expression::Break => todo!(),
+        Expression::Continue => todo!(),
+        Expression::Quant(quantifier_type, idents, expression) => todo!(),
+    };
+
+    todo!()
+}
+
+fn ast_ident_to_vir_expr(ident: &Ident) -> Expr {
+    let exprx = ExprX::Var(VarIdent(
+        Arc::new(ident.id.0.to_string()),
+        VarIdentDisambiguate::RustcId(
+            ident.id.0.try_into().expect("Failed to convert var ast id usize"),
+        ),
+    ));
+
+    SpannedTyped::new(
+        &build_span(ident.id.0, format!("Var {}", ident.name), ident.location),
+        &ast_type_to_vir_type(&ident.typ),
+        exprx,
+    )
+}
+
+fn ast_literal_to_vir_expr(literal: &Literal) -> Expr {
+    let expr = match literal {
+        Literal::Array(array_literal) => todo!(),
+        Literal::Slice(array_literal) => todo!(),
+        Literal::Integer(signed_field, ast_type, location) => {
+            let exprx = numeric_const_to_vir_exprx(signed_field);
+            SpannedTyped::new(
+                &build_span_no_id(format!("Integer literal"), Some(*location)),
+                &ast_type_to_vir_type(ast_type),
+                exprx,
+            )
+        }
+        Literal::Bool(bool_value) => {
+            let exprx = ExprX::Const(Constant::Bool(*bool_value));
+            SpannedTyped::new(
+                &build_span_no_id(format!("Boolean literal"), None),
+                &ast_type_to_vir_type(&Type::Bool),
+                exprx,
+            )
+        }
+        Literal::Unit => {
+            let exprx =
+                ExprX::Ctor(Dt::Tuple(0), Arc::new(String::new()), Arc::new(Vec::new()), None);
+            SpannedTyped::new(
+                &build_span_no_id(format!("Unit literal"), None),
+                &ast_type_to_vir_type(&Type::Unit),
+                exprx,
+            )
+        }
+        Literal::Str(_) => todo!(),
+        Literal::FmtStr(fmt_str_fragments, _, expression) => todo!(),
+    };
+
+    expr
+}
+
+fn numeric_const_to_vir_exprx(signed_field: &SignedField) -> ExprX {
+    let const_big_uint: BigUint = signed_field.field.into_repr().into();
+    let big_int_sign =
+        if signed_field.is_negative { num_bigint::Sign::Minus } else { num_bigint::Sign::Plus };
+    let const_big_int: BigInt = BigInt::from_biguint(big_int_sign, const_big_uint.clone());
+
+    ExprX::Const(Constant::Int(const_big_int))
+}
+
+fn ast_block_to_vir_expr(block: &Vec<Expression>, mode: Mode) -> Expr {
+    let stmts: Vec<Stmt> = block.iter().map(|expr| ast_expr_to_stmt(expr, mode)).collect();
+    // Get the type of the expression block by matching the last statement
+    let block_type = match stmts.last().map(|stmt| &stmt.as_ref().x) {
+        None | Some(StmtX::Decl { .. }) => make_unit_vir_type(),
+        Some(StmtX::Expr(expr)) => expr.typ.clone(),
+    };
+    let exprx = ExprX::Block(Arc::new(stmts), None);
+
+    SpannedTyped::new(&build_span_no_id(format!("Block of statements"), None), &block_type, exprx)
+}
+
+fn ast_expr_to_stmt(expr: &Expression, mode: Mode) -> Stmt {
+    if let Expression::Let(let_expr) = expr {
+        let patternx = PatternX::Var {
+            name: build_var_ident(let_expr.name.clone(), let_expr.id.0),
+            mutable: let_expr.mutable,
+        };
+        let init_expr = ast_expr_to_vir_expr(&let_expr.expression, mode);
+        let pattern = SpannedTyped::new(&init_expr.span, &init_expr.typ, patternx);
+        let stmtx =
+            StmtX::Decl { pattern: pattern, mode: Some(mode), init: Some(init_expr), els: None };
+
+        Spanned::new(build_span(let_expr.id.0, format!("Let expression"), None), stmtx)
+    } else {
+        let expr_as_vir = ast_expr_to_vir_expr(expr, mode);
+        let stmtx = StmtX::Expr(expr_as_vir.clone());
+
+        Spanned::new(expr_as_vir.span.clone(), stmtx)
+    }
+}
+
+fn ast_unary_to_vir_expr(unary_expr: &Unary, mode: Mode) -> Expr {
+    let exprx = match (unary_expr.operator, &unary_expr.result_type) {
+        (UnaryOp::Minus, _) => todo!(),
+        (UnaryOp::Not, Type::Bool) => {
+            ExprX::Unary(VirUnaryOp::Not, ast_expr_to_vir_expr(&unary_expr.rhs, mode))
+        }
+        (UnaryOp::Not, ast_type) => ExprX::Unary(
+            VirUnaryOp::BitNot(get_bit_not_bitwidth(ast_type)),
+            ast_expr_to_vir_expr(&unary_expr.rhs, mode),
+        ),
+        (UnaryOp::Reference { mutable }, ast_type) => todo!(),
+        (UnaryOp::Dereference { implicitly_added }, ast_type) => todo!(),
+    };
+
+    SpannedTyped::new(
+        &build_span_no_id(format!("Unary operation"), Some(unary_expr.location)),
+        &ast_type_to_vir_type(&unary_expr.result_type),
+        exprx,
+    )
+}
+
+fn build_var_ident(name: String, id: u32) -> VarIdent {
+    VarIdent(
+        Arc::new(name.clone()),
+        VarIdentDisambiguate::RustcId(
+            id.try_into().expect(&format!("Failed to convert id for var {}", name)),
+        ),
+    )
 }

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/mod.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/mod.rs
@@ -1,1 +1,16 @@
+use std::sync::Arc;
+
+use vir::ast::VarIdent;
+
 pub mod expr;
+pub mod params;
+pub mod types;
+
+fn id_into_var_ident(id: u32) -> VarIdent {
+    VarIdent(
+        Arc::new(id.to_string()),
+        vir::ast::VarIdentDisambiguate::RustcId(
+            id.try_into().expect(&format!("Failed to convert u32 {} to usize", id)),
+        ),
+    )
+}

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/mod.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/mod.rs
@@ -6,7 +6,7 @@ pub mod expr;
 pub mod params;
 pub mod types;
 
-fn id_into_var_ident(id: u32) -> VarIdent {
+pub fn id_into_var_ident(id: u32) -> VarIdent {
     VarIdent(
         Arc::new(id.to_string()),
         vir::ast::VarIdentDisambiguate::RustcId(

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/mod.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/mod.rs
@@ -1,1 +1,1 @@
-pub(crate) mod expr;
+pub mod expr;

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/params.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/params.rs
@@ -19,7 +19,7 @@ pub fn ast_param_to_vir_param(
     parameter: &AstParam,
     location: Location,
     mode: Mode,
-    function_name: &String,
+    function_name: &str,
 ) -> Param {
     let paramx = ParamX {
         name: id_into_var_ident(parameter.0.0),

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/params.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/params.rs
@@ -1,0 +1,36 @@
+use noirc_errors::Location;
+use noirc_frontend::{
+    monomorphization::ast::{LocalId, Type},
+    shared::Visibility,
+};
+use vir::{
+    ast::{Mode, Param, ParamX},
+    def::Spanned,
+};
+
+use crate::vir::vir_gen::{
+    build_span_no_id,
+    expr_to_vir::{id_into_var_ident, types::ast_type_to_vir_type},
+};
+
+type AstParam = (LocalId, /*mutable:*/ bool, /*name:*/ String, Type, Visibility);
+
+pub fn ast_param_to_vir_param(
+    parameter: &AstParam,
+    location: Location,
+    mode: Mode,
+    function_name: &String,
+) -> Param {
+    let paramx = ParamX {
+        name: id_into_var_ident(parameter.0.0),
+        typ: ast_type_to_vir_type(&parameter.3),
+        mode,
+        is_mut: parameter.1,
+        unwrapped_info: None, // Special unwrapping pattern which we don't support
+    };
+    Spanned::new(
+        build_span_no_id(format!("Parameters of the function {}", function_name), Some(location)),
+        paramx,
+    );
+    todo!()
+}

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/types.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/types.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+
+use noirc_frontend::{ast::IntegerBitSize, monomorphization::ast::Type, shared::Signedness};
+use num_bigint::BigInt;
+use vir::ast::{IntRange, Primitive, Typ, TypX};
+
+pub fn const_to_vir_type(number: u32) -> Typ {
+    Arc::new(TypX::ConstInt(BigInt::from(number)))
+}
+
+fn integer_type_to_vir_typx(signedness: &Signedness, bit_size: &IntegerBitSize) -> TypX {
+    match signedness {
+        Signedness::Unsigned => TypX::Int(IntRange::U(bit_size.bit_size() as u32)),
+        Signedness::Signed => TypX::Int(IntRange::I(bit_size.bit_size() as u32)),
+    }
+}
+
+pub fn ast_type_to_vir_type(ast_type: &Type) -> Typ {
+    let typx = match ast_type {
+        Type::Field => TypX::Int(IntRange::Int),
+        Type::Array(len, inner_type) => TypX::Primitive(
+            Primitive::Array,
+            Arc::new(vec![ast_type_to_vir_type(&inner_type), const_to_vir_type(*len)]),
+        ),
+        Type::Integer(signedness, integer_bit_size) => {
+            integer_type_to_vir_typx(signedness, integer_bit_size)
+        }
+        Type::Bool => TypX::Bool,
+        Type::String(_) => todo!(),
+        Type::FmtString(_, _) => todo!(),
+        Type::Unit => todo!(),
+        Type::Tuple(items) => todo!(),
+        Type::Slice(_) => todo!(),
+        Type::Reference(_, _) => todo!(),
+        Type::Function(items, _, _, _) => todo!(),
+    };
+
+    Arc::new(typx)
+}

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/types.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/types.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
+use acvm::{AcirField, FieldElement};
 use noirc_frontend::{ast::IntegerBitSize, monomorphization::ast::Type, shared::Signedness};
 use num_bigint::BigInt;
-use vir::ast::{IntRange, Primitive, Typ, TypX};
+use vir::ast::{Dt, IntRange, IntegerTypeBitwidth, Primitive, Typ, TypX};
 
 pub fn const_to_vir_type(number: u32) -> Typ {
     Arc::new(TypX::ConstInt(BigInt::from(number)))
@@ -13,6 +14,11 @@ fn integer_type_to_vir_typx(signedness: &Signedness, bit_size: &IntegerBitSize) 
         Signedness::Unsigned => TypX::Int(IntRange::U(bit_size.bit_size() as u32)),
         Signedness::Signed => TypX::Int(IntRange::I(bit_size.bit_size() as u32)),
     }
+}
+
+// Returns the VIR unit type (also known as void type)
+pub fn make_unit_vir_type() -> Typ {
+    Arc::new(TypX::Datatype(Dt::Tuple(0), Arc::new(Vec::new()), Arc::new(Vec::new())))
 }
 
 pub fn ast_type_to_vir_type(ast_type: &Type) -> Typ {
@@ -28,7 +34,7 @@ pub fn ast_type_to_vir_type(ast_type: &Type) -> Typ {
         Type::Bool => TypX::Bool,
         Type::String(_) => todo!(),
         Type::FmtString(_, _) => todo!(),
-        Type::Unit => todo!(),
+        Type::Unit => TypX::Datatype(Dt::Tuple(0), Arc::new(Vec::new()), Arc::new(Vec::new())),
         Type::Tuple(items) => todo!(),
         Type::Slice(_) => todo!(),
         Type::Reference(_, _) => todo!(),
@@ -36,4 +42,24 @@ pub fn ast_type_to_vir_type(ast_type: &Type) -> Typ {
     };
 
     Arc::new(typx)
+}
+
+fn get_integer_type_bitwidth(integer_type: &Type) -> IntegerTypeBitwidth {
+    match integer_type {
+        Type::Field => IntegerTypeBitwidth::Width(FieldElement::max_num_bits()),
+        Type::Integer(_, integer_bit_size) => {
+            IntegerTypeBitwidth::Width(integer_bit_size.bit_size() as u32)
+        }
+        _ => unreachable!("Can get a bit width only of integer types"),
+    }
+}
+
+/// Similar to `get_integer_type_bitwidth` but we have a different logic
+/// for the types Field and Signed integer
+pub fn get_bit_not_bitwidth(integer_type: &Type) -> Option<IntegerTypeBitwidth> {
+    match integer_type {
+        Type::Field | Type::Integer(Signedness::Signed, _) => None,
+        Type::Integer(Signedness::Unsigned, _) => Some(get_integer_type_bitwidth(integer_type)),
+        _ => unreachable!("Can get a bit width only of integer types"),
+    }
 }

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/types.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/types.rs
@@ -11,14 +11,18 @@ pub fn const_to_vir_type(number: u32) -> Typ {
 
 fn integer_type_to_vir_typx(signedness: &Signedness, bit_size: &IntegerBitSize) -> TypX {
     match signedness {
-        Signedness::Unsigned => TypX::Int(IntRange::U(bit_size.bit_size() as u32)),
-        Signedness::Signed => TypX::Int(IntRange::I(bit_size.bit_size() as u32)),
+        Signedness::Unsigned => TypX::Int(IntRange::U(bit_size.bit_size().into())),
+        Signedness::Signed => TypX::Int(IntRange::I(bit_size.bit_size().into())),
     }
 }
 
 // Returns the VIR unit type (also known as void type)
 pub fn make_unit_vir_type() -> Typ {
-    Arc::new(TypX::Datatype(Dt::Tuple(0), Arc::new(Vec::new()), Arc::new(Vec::new())))
+    Arc::new(make_unit_vir_typx())
+}
+
+fn make_unit_vir_typx() -> TypX {
+    TypX::Datatype(Dt::Tuple(0), Arc::new(Vec::new()), Arc::new(Vec::new()))
 }
 
 pub fn ast_type_to_vir_type(ast_type: &Type) -> Typ {
@@ -34,7 +38,7 @@ pub fn ast_type_to_vir_type(ast_type: &Type) -> Typ {
         Type::Bool => TypX::Bool,
         Type::String(_) => todo!(),
         Type::FmtString(_, _) => todo!(),
-        Type::Unit => TypX::Datatype(Dt::Tuple(0), Arc::new(Vec::new()), Arc::new(Vec::new())),
+        Type::Unit => make_unit_vir_typx(),
         Type::Tuple(items) => todo!(),
         Type::Slice(_) => todo!(),
         Type::Reference(_, _) => todo!(),
@@ -55,11 +59,17 @@ fn get_integer_type_bitwidth(integer_type: &Type) -> IntegerTypeBitwidth {
 }
 
 /// Similar to `get_integer_type_bitwidth` but we have a different logic
-/// for the types Field and Signed integer
-pub fn get_bit_not_bitwidth(integer_type: &Type) -> Option<IntegerTypeBitwidth> {
+/// for the types Field and Signed integer.
+/// Will `panic` if the type is not an integer.
+pub(crate) fn get_bit_not_bitwidth(integer_type: &Type) -> Option<IntegerTypeBitwidth> {
     match integer_type {
         Type::Field | Type::Integer(Signedness::Signed, _) => None,
         Type::Integer(Signedness::Unsigned, _) => Some(get_integer_type_bitwidth(integer_type)),
-        _ => unreachable!("Can get a bit width only of integer types"),
+        _ => {
+            // All Noir binary expression have gone through type checking
+            // during the elaboration phase in `compiler/noirc_frontend/src/elaborator`.
+            // Therefore we can assume that bit not operation only occurs with integers.
+            unreachable!("Can get a bit width only of integer types")
+        }
     }
 }

--- a/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
@@ -146,7 +146,7 @@ pub fn build_funx(
         unwind_spec: None,   // To be able to use functions from Verus std we need None on unwinding
         item_kind: ItemKind::Function,
         attrs: build_default_funx_attrs(function.parameters.is_empty(), !function.unconstrained),
-        body: Some(func_body_to_vir_expr(function)),
+        body: Some(func_body_to_vir_expr(function, mode)),
         extra_dependencies: Vec::new(),
     };
 

--- a/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
@@ -43,7 +43,7 @@ fn get_function_params(function: &Function, mode: Mode) -> Result<Params, Buildi
     let params_as_vir: Vec<Param> = function
         .parameters
         .iter()
-        .zip(locations.into_iter())
+        .zip(locations)
         .map(|(param, location)| ast_param_to_vir_param(param, location, mode, &function.name))
         .collect();
 

--- a/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
@@ -92,7 +92,7 @@ pub fn build_funx(
             visibility: Visibility { restricted_to: None }, // We currently don't support opaqueness control
         },
         owning_module: Some(current_module.x.path.clone()), // The module in which this function is located.
-        mode: get_function_mode(is_ghost),
+        mode,
         typ_params: Arc::new(Vec::new()), // There are no generics in Monomorphized AST
         typ_bounds: Arc::new(Vec::new()), // There are no generics in Monomorphized AST
         params: function_params,

--- a/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
@@ -43,7 +43,7 @@ fn build_default_funx_attrs(zero_args: bool) -> FunctionAttrs {
 }
 
 // Converts the given Monomorphized AST function into a VIR function.
-pub(crate) fn build_funx(
+pub fn build_funx(
     function: &Function,
     current_module: &Module,
 ) -> Result<FunctionX, BuildingKrateError> {

--- a/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/function.rs
@@ -27,10 +27,6 @@ fn is_ghost_function(function: &Function) -> bool {
         .any(|x| matches!(x, MonomorphizedFvAttribute::Ghost))
 }
 
-fn get_function_opaqueness(is_ghost: bool) -> Opaqueness {
-    todo!()
-}
-
 fn get_function_mode(is_ghost: bool) -> Mode {
     if is_ghost { Mode::Spec } else { Mode::Exec }
 }
@@ -92,7 +88,9 @@ pub fn build_funx(
         body_visibility: BodyVisibility::Visibility(Visibility {
             restricted_to: None, // We currently support only fully visible ghost functions
         }),
-        opaqueness: get_function_opaqueness(is_ghost),
+        opaqueness: Opaqueness::Revealed {
+            visibility: Visibility { restricted_to: None }, // We currently don't support opaqueness control
+        },
         owning_module: Some(current_module.x.path.clone()), // The module in which this function is located.
         mode: get_function_mode(is_ghost),
         typ_params: Arc::new(Vec::new()), // There are no generics in Monomorphized AST

--- a/compiler/noirc_evaluator/src/vir/vir_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/mod.rs
@@ -1,6 +1,6 @@
-mod attribute;
-mod expr_to_vir;
-mod function;
+pub mod attribute;
+pub mod expr_to_vir;
+pub mod function;
 
 use function::build_funx;
 use noirc_errors::Location;


### PR DESCRIPTION
This PR is a step towards of having a minimally verifiable Noir program. Not all expressions have been translated from monomorphized AST to VIR. The remaining TODOs will be implemented in later PRs.

Next step is to integrate Venir and pass the generated VIR to it.