### PR TITLE
feat(ast-to-vir): Convert FV annotations to VIR

### DIFF
--- a/compiler/noirc_evaluator/src/vir/vir_gen/attribute.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/attribute.rs
@@ -1,12 +1,36 @@
 use std::sync::Arc;
 
-use noirc_frontend::monomorphization::ast::Function;
-use vir::ast::Exprs;
+use noirc_frontend::monomorphization::ast::{Function, MonomorphizedFvAttribute};
+use vir::ast::{Exprs, Mode};
+
+use crate::vir::vir_gen::expr_to_vir::expr::ast_expr_to_vir_expr;
 
 pub fn func_requires_to_vir_expr(func: &Function) -> Exprs {
-    Arc::new(Vec::new()) //TODO(totel)
+    Arc::new(
+        func.formal_verification_attributes
+            .iter()
+            .filter_map(|attribute| {
+                if let MonomorphizedFvAttribute::Requires(expression) = attribute {
+                    Some(ast_expr_to_vir_expr(expression, Mode::Spec))
+                } else {
+                    None
+                }
+            })
+            .collect(),
+    )
 }
 
 pub fn func_ensures_to_vir_expr(func: &Function) -> Exprs {
-    Arc::new(Vec::new()) //TODO(totel)
+    Arc::new(
+        func.formal_verification_attributes
+            .iter()
+            .filter_map(|attribute| {
+                if let MonomorphizedFvAttribute::Ensures(expression) = attribute {
+                    Some(ast_expr_to_vir_expr(expression, Mode::Spec))
+                } else {
+                    None
+                }
+            })
+            .collect(),
+    )
 }

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/types.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/types.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use acvm::{AcirField, FieldElement};
-use noirc_frontend::{ast::IntegerBitSize, monomorphization::ast::Type, shared::Signedness};
+use noirc_frontend::{ast::{BinaryOpKind, IntegerBitSize}, monomorphization::ast::Type, shared::Signedness};
 use num_bigint::BigInt;
 use vir::ast::{Dt, IntRange, IntegerTypeBitwidth, Primitive, Typ, TypX};
 
@@ -73,6 +73,14 @@ pub(crate) fn get_bit_not_bitwidth(integer_type: &Type) -> Option<IntegerTypeBit
             // Therefore we can assume that bit not operation only occurs with integers.
             unreachable!("Can get a bit width only of integer types")
         }
+    }
+}
+
+pub fn get_binary_op_type(lhs_type: Typ, binary_op: &BinaryOpKind) -> Typ {
+    if binary_op.is_comparator() || binary_op.is_equality() || binary_op.is_implication() {
+        Arc::new(TypX::Bool)
+    } else {
+        lhs_type
     }
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2516,7 +2516,14 @@ impl<'interner> Monomorphizer<'interner> {
         let definition: ast::Definition = Definition::Local(new_id);
 
         let typ = Self::convert_type(&self.interner.definition_type(ident.id), ident.location)?;
-        Ok(ast::Ident { location: Some(ident.location), mutable, definition, name, typ, id: ident_id })
+        Ok(ast::Ident {
+            location: Some(ident.location),
+            mutable,
+            definition,
+            name,
+            typ,
+            id: ident_id,
+        })
     }
 
     fn quantifier(


### PR DESCRIPTION
Convert pre/post-conditions from AST to VIR.
Also we are now using the proper ids when we are converting AST identifiers to VIR.

No tests have been added to this PR because some issues were discovered with the variable `result`.