### PR TITLE
fix(ast-to-vir): Correct processing of the `result` variable

### DIFF
--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/expr.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/expr.rs
@@ -13,10 +13,10 @@ use crate::vir::vir_gen::{
 use noirc_errors::Location;
 use noirc_frontend::{
     ast::{BinaryOpKind, QuantifierType, UnaryOp},
-    monomorphization::ast::{
+    monomorphization::{ast::{
         Assign, Binary, Call, Cast, Definition, Expression, Function, Ident, If, LValue, Literal,
         Match, Type, Unary,
-    },
+    }, FUNC_RETURN_VAR_NAME},
     shared::Signedness,
     signed_field::SignedField,
 };
@@ -106,7 +106,7 @@ fn ast_ident_to_vir_expr(ident: &Ident) -> Expr {
     // during the Monomorphization of the AST. This is the "result" variable which
     // you can refer from `ensures` attributes. We define it as AirLocal because
     // we want to differentiate it from normal variables.
-    let var_disambiguate = if ident.name == "%return" {
+    let var_disambiguate = if ident.name == FUNC_RETURN_VAR_NAME {
         VarIdentDisambiguate::AirLocal
     } else {
         VarIdentDisambiguate::RustcId(

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -47,6 +47,14 @@ use self::{
     errors::MonomorphizationError,
 };
 
+/// This is the variable name which we assign to the special variable named "result".
+/// The special variable "result" can be referred only in `ensures` attributes
+/// and its value is the body expression of the function to which the `ensures`
+/// attribute is attached to.
+/// The leading `%` makes it an illegal identifier which ensures that it won't
+/// clash with existing identifiers. 
+pub const FUNC_RETURN_VAR_NAME: &str = "%return";
+
 pub mod ast;
 mod debug;
 pub mod debug_types;
@@ -1112,7 +1120,7 @@ impl<'interner> Monomorphizer<'interner> {
                     let Some(ident) = self.local_ident(&ident, &typ)? else {
                         // Inside ensures attributes we can use a "result" variable as
                         // the function output, though that variable isn't defined in our code.
-                        // We cannot define a normal variable, since the way the monomorphized ast
+                        // We cannot define a normal variable, because of the way the monomorphized ast
                         // is made, we'll copy the entire program.
                         // Instead, we'll pass a "marker" value down to the VIR gen module, so it can be
                         // handled accordingly there.
@@ -1129,7 +1137,7 @@ impl<'interner> Monomorphizer<'interner> {
                                     0: self.interner.definition_count().to_u32().unwrap_or(0),
                                 }),
                                 mutable: false,
-                                name: "%return".to_string(), // Change the name from "result" to "%return"
+                                name: FUNC_RETURN_VAR_NAME.to_string(), // Change the name from "result" to "%return"
                                 typ: Self::convert_type(&typ, self.interner.id_location(expr_id))?,
                                 id: self.next_ident_id(),
                             }));

--- a/test_programs/formal_verify_success/bitshifts/Nargo.toml
+++ b/test_programs/formal_verify_success/bitshifts/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_bitshifts"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/bitshifts/src/main.nr
+++ b/test_programs/formal_verify_success/bitshifts/src/main.nr
@@ -1,0 +1,17 @@
+#[requires((x < 10) & (y < 3))]
+fn main(x: u32, y: u8) {
+    let _ = lbs(x, y);
+    let _ = rbs(x, y);
+}
+
+#[requires((x < 10) & (y < 3))]
+#[ensures(result == x << y)]
+fn lbs(x: u32, y: u8) -> u32 {
+    x << y
+}
+
+#[requires((x < 10) & (y < 3))]
+#[ensures(result == x >> y)]
+fn rbs(x: u32, y: u8) -> u32 {
+    x >> y
+}

--- a/test_programs/formal_verify_success/boolean/Nargo.toml
+++ b/test_programs/formal_verify_success/boolean/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_boolean"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/boolean/src/main.nr
+++ b/test_programs/formal_verify_success/boolean/src/main.nr
@@ -1,0 +1,26 @@
+fn main(x: bool, y: bool) {
+	let _ = xor(x, y);
+	let _ = and(x, y);
+	let _ = or(x, y);
+	let _ = not(x);
+}
+
+#[ensures(result == x ^ y)]
+fn xor(x: bool, y: bool) -> bool {
+    x ^ y
+}
+
+#[ensures(result == x & y)]
+fn and(x: bool, y: bool) -> bool {
+    x & y
+}
+
+#[ensures(result == x | y)]
+fn or(x: bool, y: bool) -> bool {
+    x | y
+}
+
+#[ensures(result == ! x)]
+fn not(x: bool) -> bool {
+    ! x
+}

--- a/test_programs/formal_verify_success/cast/Nargo.toml
+++ b/test_programs/formal_verify_success/cast/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_cast"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/cast/src/main.nr
+++ b/test_programs/formal_verify_success/cast/src/main.nr
@@ -1,0 +1,4 @@
+#[ensures(result == (x as u32) as u8)]
+fn main(x: u16) -> pub u8 {
+	(x as u32) as u8
+}

--- a/test_programs/formal_verify_success/cast_from_to_field/Nargo.toml
+++ b/test_programs/formal_verify_success/cast_from_to_field/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cast_to_avoid_field"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/cast_from_to_field/src/main.nr
+++ b/test_programs/formal_verify_success/cast_from_to_field/src/main.nr
@@ -1,0 +1,5 @@
+#[requires((x == 0) | (x == 1))]
+fn main(x: Field) -> pub Field {
+    ((x as u32) + 1) as Field
+}
+

--- a/test_programs/formal_verify_success/comparison/Nargo.toml
+++ b/test_programs/formal_verify_success/comparison/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_comparison"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/comparison/src/main.nr
+++ b/test_programs/formal_verify_success/comparison/src/main.nr
@@ -1,0 +1,38 @@
+fn main(x: u8, y: u8) {
+    let _ = lt(x, y);
+    let _ = lte(x, y);
+    let _ = gt(y, x);
+    let _ = gte(y, x);
+    let _ = eq(x, x);
+    let _ = neq(x, y);
+}
+
+#[ensures(result == (x < y))]
+fn lt(x: u8, y: u8) -> bool {
+    x < y
+}
+
+#[ensures(result == (x <= y))]
+fn lte(x: u8, y: u8) -> bool {
+    x <= y
+}
+
+#[ensures(result == (x > y))]
+fn gt(x: u8, y: u8) -> bool {
+    x > y
+}
+
+#[ensures(result == (x >= y))]
+fn gte(x: u8, y: u8) -> bool {
+    x >= y
+}
+
+#[ensures(result == (x == y))]
+fn eq(x: u8, y: u8) -> bool {
+    x == y
+}
+
+#[ensures(result == (x != y))]
+fn neq(x: u8, y: u8) -> bool {
+    x != y
+}

--- a/test_programs/formal_verify_success/field_arithmetic/Nargo.toml
+++ b/test_programs/formal_verify_success/field_arithmetic/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_field"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/field_arithmetic/src/main.nr
+++ b/test_programs/formal_verify_success/field_arithmetic/src/main.nr
@@ -1,0 +1,28 @@
+// Fields wrap around when overflowing. Therefore this program
+// should not produce a "potential overflow" error.
+fn main(x: Field, y: Field) {
+    let _ = plus(x, y);
+    let _ = minus(x, y);
+    let _ = mult(x, y);
+    let _ = div(x, y);
+}
+
+#[ensures(result == x + y)]
+fn plus(x: Field, y: Field) -> Field {
+    x + y
+}
+
+#[ensures(result == x - y)]
+fn minus(x: Field, y: Field) -> Field {
+    x - y
+}
+
+#[ensures(result == x * y)]
+fn mult(x: Field, y: Field) -> Field {
+    x * y
+}
+
+#[ensures(result == x / y)]
+fn div(x: Field, y: Field) -> Field {
+    x / y
+}

--- a/test_programs/formal_verify_success/func_call_in_if/Nargo.toml
+++ b/test_programs/formal_verify_success/func_call_in_if/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "func_call_in_if"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/func_call_in_if/src/main.nr
+++ b/test_programs/formal_verify_success/func_call_in_if/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: u32) -> pub u32 {
+    if x > 5 { foo(x) } else { x }
+}
+
+#[requires(x > 5)]
+fn foo(x: u32) -> u32 {
+    0
+}

--- a/test_programs/formal_verify_success/func_call_in_if_2/Nargo.toml
+++ b/test_programs/formal_verify_success/func_call_in_if_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "func_call_in_if"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/func_call_in_if_2/src/main.nr
+++ b/test_programs/formal_verify_success/func_call_in_if_2/src/main.nr
@@ -1,0 +1,8 @@
+fn main(x: u32) -> pub (u32, u32) {
+    if x > 5 { foo(x) } else { (x, x) }
+}
+
+#[requires(x > 5)]
+fn foo(x: u32) -> (u32, u32) {
+    (0, 0)
+}

--- a/test_programs/formal_verify_success/fv_attribute_name_resolution_1/Nargo.toml
+++ b/test_programs/formal_verify_success/fv_attribute_name_resolution_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/fv_attribute_name_resolution_1/src/main.nr
+++ b/test_programs/formal_verify_success/fv_attribute_name_resolution_1/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {}
+
+#[requires(x as u32 > 5)] // as u32 because fields can not be compared
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/formal_verify_success/fv_attribute_name_resolution_2/Nargo.toml
+++ b/test_programs/formal_verify_success/fv_attribute_name_resolution_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/fv_attribute_name_resolution_2/src/main.nr
+++ b/test_programs/formal_verify_success/fv_attribute_name_resolution_2/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {}
+
+#[ensures(result as u32 > 5)]  // result can be only used in the ensures attribute
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/formal_verify_success/fv_attribute_name_resolution_3/Nargo.toml
+++ b/test_programs/formal_verify_success/fv_attribute_name_resolution_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_name_resolution"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/fv_attribute_name_resolution_3/src/main.nr
+++ b/test_programs/formal_verify_success/fv_attribute_name_resolution_3/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {}
+
+#[ensures(result == x + x)]
+fn foo(x: Field) -> Field {
+  x + x
+}

--- a/test_programs/formal_verify_success/fv_attribute_type_check_1/Nargo.toml
+++ b/test_programs/formal_verify_success/fv_attribute_type_check_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/fv_attribute_type_check_1/src/main.nr
+++ b/test_programs/formal_verify_success/fv_attribute_type_check_1/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[requires(x)]
+fn foo(x: bool) -> Field {
+  5
+}
+

--- a/test_programs/formal_verify_success/fv_attribute_type_check_2/Nargo.toml
+++ b/test_programs/formal_verify_success/fv_attribute_type_check_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/fv_attribute_type_check_2/src/main.nr
+++ b/test_programs/formal_verify_success/fv_attribute_type_check_2/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[ensures(result)]
+fn foo() -> bool {
+  true
+}
+

--- a/test_programs/formal_verify_success/fv_attribute_type_check_3/Nargo.toml
+++ b/test_programs/formal_verify_success/fv_attribute_type_check_3/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_attribute_type_check_fail_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/fv_attribute_type_check_3/src/main.nr
+++ b/test_programs/formal_verify_success/fv_attribute_type_check_3/src/main.nr
@@ -1,0 +1,5 @@
+fn main() {}
+
+#[requires(5 > 5)]
+fn foo() {}
+

--- a/test_programs/formal_verify_success/identity_function/Nargo.toml
+++ b/test_programs/formal_verify_success/identity_function/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "target_program"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/formal_verify_success/identity_function/src/main.nr
+++ b/test_programs/formal_verify_success/identity_function/src/main.nr
@@ -1,0 +1,4 @@
+#[ensures(result == x)]
+fn main(x: u32) -> pub u32 {
+  x
+}

--- a/test_programs/formal_verify_success/if_overflow_1/Nargo.toml
+++ b/test_programs/formal_verify_success/if_overflow_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "if_test_overflow_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/if_overflow_1/src/main.nr
+++ b/test_programs/formal_verify_success/if_overflow_1/src/main.nr
@@ -1,0 +1,10 @@
+// Verification should pass because all overflows
+// are prevented by the if condition
+fn main(x: u8) -> pub u8 {
+    if x < 255 {
+        x + 1
+    }
+    else {
+        0
+    }
+}

--- a/test_programs/formal_verify_success/if_overflow_2/Nargo.toml
+++ b/test_programs/formal_verify_success/if_overflow_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "if_test_overflow_2"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/if_overflow_2/src/main.nr
+++ b/test_programs/formal_verify_success/if_overflow_2/src/main.nr
@@ -1,0 +1,14 @@
+// Verification should pass because all overflows
+// are prevented by the if condition.
+// We also expect the requires clause 
+// to work correctly and make the test
+// equivalent to if_test_overflow_1
+#[requires(y == 255)]
+fn main(x: u8, y: u8) -> pub u8 {
+    if x < y {
+        x + 1
+    }
+    else {
+        0
+    }
+}

--- a/test_programs/formal_verify_success/if_overflow_complex/Nargo.toml
+++ b/test_programs/formal_verify_success/if_overflow_complex/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "if_test_overflow_complex"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/if_overflow_complex/src/main.nr
+++ b/test_programs/formal_verify_success/if_overflow_complex/src/main.nr
@@ -1,0 +1,14 @@
+// This test is slightly more complex
+// because it conatins nested ifs
+fn main(x: u8) -> pub u8 {
+    if x >= 255 {
+        0
+    }
+    else {
+        if x > 12 {
+          x - 1
+        } else {
+          x + 1
+        }
+    }
+}

--- a/test_programs/formal_verify_success/implication_operator_1/Nargo.toml
+++ b/test_programs/formal_verify_success/implication_operator_1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "implication_operator"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/implication_operator_1/src/main.nr
+++ b/test_programs/formal_verify_success/implication_operator_1/src/main.nr
@@ -1,0 +1,8 @@
+#[ensures((y ==> result == x) & (!y ==> result == 0))]
+fn main(x: u32, y: bool) -> pub u32 {
+    if y {
+        x
+    } else {
+        0
+    }
+}

--- a/test_programs/formal_verify_success/integer_div/Nargo.toml
+++ b/test_programs/formal_verify_success/integer_div/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_integer_div"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/integer_div/src/main.nr
+++ b/test_programs/formal_verify_success/integer_div/src/main.nr
@@ -1,0 +1,59 @@
+#[requires((-10 < x) & (x < 10) & (0 < y) & (y < 10))]
+fn main(x: i64, y: i64) {
+    let _ = integer_i8(x as i8, y as i8);
+    let _ = integer_i16(x as i16, y as i16);
+    let _ = integer_i32(x as i32, y as i32);
+    let _ = integer_i64(x, y);
+    let _ = integer_u8(x as u8, y as u8);
+    let _ = integer_u16(x as u16, y as u16);
+    let _ = integer_u32(x as u32, y as u32);
+    let _ = integer_u64(x as u64, y as u64);
+}
+
+#[requires(y != 0)]
+#[ensures(result == x / y)]
+fn integer_i8(x: i8, y: i8) -> i8 {
+    x / y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x / y)]
+fn integer_i16(x: i16, y: i16) -> i16 {
+    x / y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x / y)]
+fn integer_i32(x: i32, y: i32) -> i32 {
+    x / y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x / y)]
+fn integer_i64(x: i64, y: i64) -> i64 {
+    x / y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x / y)]
+fn integer_u8(x: u8, y: u8) -> u8 {
+    x / y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x / y)]
+fn integer_u16(x: u16, y: u16) -> u16 {
+    x / y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x / y)]
+fn integer_u32(x: u32, y: u32) -> u32 {
+    x / y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x / y)]
+fn integer_u64(x: u64, y: u64) -> u64 {
+    x / y
+}

--- a/test_programs/formal_verify_success/integer_mod/Nargo.toml
+++ b/test_programs/formal_verify_success/integer_mod/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_integer_mod"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/integer_mod/src/main.nr
+++ b/test_programs/formal_verify_success/integer_mod/src/main.nr
@@ -1,0 +1,59 @@
+#[requires((-10 < x) & (x < 10) & (0 < y) & (y < 10))]
+fn main(x: i64, y: i64) {
+    let _ = integer_i8(x as i8, y as i8);
+    let _ = integer_i16(x as i16, y as i16);
+    let _ = integer_i32(x as i32, y as i32);
+    let _ = integer_i64(x, y);
+    let _ = integer_u8(x as u8, y as u8);
+    let _ = integer_u16(x as u16, y as u16);
+    let _ = integer_u32(x as u32, y as u32);
+    let _ = integer_u64(x as u64, y as u64);
+}
+
+#[requires(y != 0)]
+#[ensures(result == x % y)]
+fn integer_i8(x: i8, y: i8) -> i8 {
+    x % y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x % y)]
+fn integer_i16(x: i16, y: i16) -> i16 {
+    x % y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x % y)]
+fn integer_i32(x: i32, y: i32) -> i32 {
+    x % y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x % y)]
+fn integer_i64(x: i64, y: i64) -> i64 {
+    x % y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x % y)]
+fn integer_u8(x: u8, y: u8) -> u8 {
+    x % y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x % y)]
+fn integer_u16(x: u16, y: u16) -> u16 {
+    x % y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x % y)]
+fn integer_u32(x: u32, y: u32) -> u32 {
+    x % y
+}
+
+#[requires(y != 0)]
+#[ensures(result == x % y)]
+fn integer_u64(x: u64, y: u64) -> u64 {
+    x % y
+}

--- a/test_programs/formal_verify_success/integer_not/Nargo.toml
+++ b/test_programs/formal_verify_success/integer_not/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_integer_not"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/integer_not/src/main.nr
+++ b/test_programs/formal_verify_success/integer_not/src/main.nr
@@ -1,0 +1,59 @@
+#[requires((0 < x) & (x < 10))]
+fn main(x: i64) {
+    let _ = integer_i8(x as i8);
+    let _ = integer_i16(x as i16);
+    let _ = integer_i32(x as i32);
+    let _ = integer_i64(x);
+    let _ = integer_u8(x as u8);
+    let _ = integer_u16(x as u16);
+    let _ = integer_u32(x as u32);
+    let _ = integer_u64(x as u64);
+}
+
+#[requires((0 < x) & (x < 10))]
+#[ensures(result == ! x)]
+fn integer_i8(x: i8) -> i8 {
+    ! x
+}
+
+#[requires((0 < x) & (x < 10))]
+#[ensures(result == ! x)]
+fn integer_i16(x: i16) -> i16 {
+    ! x
+}
+
+#[requires((0 < x) & (x < 10))]
+#[ensures(result == ! x)]
+fn integer_i32(x: i32) -> i32 {
+    ! x
+}
+
+#[requires((0 < x) & (x < 10))]
+#[ensures(result == ! x)]
+fn integer_i64(x: i64) -> i64 {
+    ! x
+}
+
+#[requires(x < 10)]
+#[ensures(result == ! x)]
+fn integer_u8(x: u8) -> u8 {
+    ! x
+}
+
+#[requires(x < 10)]
+#[ensures(result == ! x)]
+fn integer_u16(x: u16) -> u16 {
+    ! x
+}
+
+#[requires(x < 10)]
+#[ensures(result == ! x)]
+fn integer_u32(x: u32) -> u32 {
+    ! x
+}
+
+#[requires(x < 10)]
+#[ensures(result == ! x)]
+fn integer_u64(x: u64) -> u64 {
+    ! x
+}

--- a/test_programs/formal_verify_success/integer_sub/Nargo.toml
+++ b/test_programs/formal_verify_success/integer_sub/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_integer_sub"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/integer_sub/src/main.nr
+++ b/test_programs/formal_verify_success/integer_sub/src/main.nr
@@ -1,0 +1,59 @@
+#[requires((10 < x) & (x < 100) & (0 < y) & (y < 10))]
+fn main(x: i64, y: i64) {
+    let _ = integer_i8(x as i8, y as i8);
+    let _ = integer_i16(x as i16, y as i16);
+    let _ = integer_i32(x as i32, y as i32);
+    let _ = integer_i64(x, y);
+    let _ = integer_u8(x as u8, y as u8);
+    let _ = integer_u16(x as u16, y as u16);
+    let _ = integer_u32(x as u32, y as u32);
+    let _ = integer_u64(x as u64, y as u64);
+}
+
+#[requires((10 < x) & (x < 100) & (0 < y) & (y < 10))]
+#[ensures(result == x - y)]
+fn integer_i8(x: i8, y: i8) -> i8 {
+    x - y
+}
+
+#[requires((10 < x) & (x < 100) & (0 < y) & (y < 10))]
+#[ensures(result == x - y)]
+fn integer_i16(x: i16, y: i16) -> i16 {
+    x - y
+}
+
+#[requires((10 < x) & (x < 100) & (0 < y) & (y < 10))]
+#[ensures(result == x - y)]
+fn integer_i32(x: i32, y: i32) -> i32 {
+    x - y
+}
+
+#[requires((10 < x) & (x < 100) & (0 < y) & (y < 10))]
+#[ensures(result == x - y)]
+fn integer_i64(x: i64, y: i64) -> i64 {
+    x - y
+}
+
+#[requires((10 < x) & (x < 100) & (y < 10))]
+#[ensures(result == x - y)]
+fn integer_u8(x: u8, y: u8) -> u8 {
+    x - y
+}
+
+#[requires((10 < x) & (x < 100) & (y < 10))]
+#[ensures(result == x - y)]
+fn integer_u16(x: u16, y: u16) -> u16 {
+    x - y
+}
+
+#[requires((10 < x) & (x < 100) & (y < 10))]
+#[ensures(result == x - y)]
+fn integer_u32(x: u32, y: u32) -> u32 {
+    x - y
+}
+
+#[requires((10 < x) & (x < 100) & (y < 10))]
+#[ensures(result == x - y)]
+fn integer_u64(x: u64, y: u64) -> u64 {
+    x - y
+}

--- a/test_programs/formal_verify_success/integer_sum/Nargo.toml
+++ b/test_programs/formal_verify_success/integer_sum/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_integer_sum"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/integer_sum/src/main.nr
+++ b/test_programs/formal_verify_success/integer_sum/src/main.nr
@@ -1,0 +1,59 @@
+#[requires((0 < x) & (x < 10) & (0 < y) & (y < 10))]
+fn main(x: u64, y: u64) {
+    let _ = integer_i8(x as i8, y as i8);
+    let _ = integer_i16(x as i16, y as i16);
+    let _ = integer_i32(x as i32, y as i32);
+    let _ = integer_i64(x as i64, y as i64);
+    let _ = integer_u8(x as u8, y as u8);
+    let _ = integer_u16(x as u16, y as u16);
+    let _ = integer_u32(x as u32, y as u32);
+    let _ = integer_u64(x, y);
+}
+
+#[requires((0 < x) & (x < 10) & (0 < y) & (y < 10))]
+#[ensures(result == x + y)]
+fn integer_i8(x: i8, y: i8) -> i8 {
+    x + y
+}
+
+#[requires((0 < x) & (x < 10) & (0 < y) & (y < 10))]
+#[ensures(result == x + y)]
+fn integer_i16(x: i16, y: i16) -> i16 {
+    x + y
+}
+
+#[requires((0 < x) & (x < 10) & (0 < y) & (y < 10))]
+#[ensures(result == x + y)]
+fn integer_i32(x: i32, y: i32) -> i32 {
+    x + y
+}
+
+#[requires((0 < x) & (x < 10) & (0 < y) & (y < 10))]
+#[ensures(result == x + y)]
+fn integer_i64(x: i64, y: i64) -> i64 {
+    x + y
+}
+
+#[requires((x < 10) & (y < 10))]
+#[ensures(result == x + y)]
+fn integer_u8(x: u8, y: u8) -> u8 {
+    x + y
+}
+
+#[requires((x < 10) & (y < 10))]
+#[ensures(result == x + y)]
+fn integer_u16(x: u16, y: u16) -> u16 {
+    x + y
+}
+
+#[requires((x < 10) & (y < 10))]
+#[ensures(result == x + y)]
+fn integer_u32(x: u32, y: u32) -> u32 {
+    x + y
+}
+
+#[requires((x < 10) & (y < 10))]
+#[ensures(result == x + y)]
+fn integer_u64(x: u64, y: u64) -> u64 {
+    x + y
+}

--- a/test_programs/formal_verify_success/is_even/Nargo.toml
+++ b/test_programs/formal_verify_success/is_even/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "is_even"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/is_even/src/main.nr
+++ b/test_programs/formal_verify_success/is_even/src/main.nr
@@ -1,0 +1,9 @@
+#[requires((x % 2 == 0) & (z % 2 == 0)
+                        & (x < z )
+                        & (z < 1000))]
+#[ensures(result == 0)]
+fn main(x: u32, z: u32) -> pub u32 {
+    let mut y = x + z;
+     y % 2
+}
+

--- a/test_programs/formal_verify_success/operation_comutativity/Nargo.toml
+++ b/test_programs/formal_verify_success/operation_comutativity/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_operation_comutativity"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/operation_comutativity/src/main.nr
+++ b/test_programs/formal_verify_success/operation_comutativity/src/main.nr
@@ -1,0 +1,17 @@
+#[requires(x < 127)]
+fn main(x: u8) {
+    let _ = left(x);
+    let _ = right(x);
+}
+
+#[requires(x <= 126)]
+#[ensures(result == ((x + 1) * 2))]
+fn left(x: u8) -> u8 {
+    (x + 1) * 2
+}
+
+#[requires(x <= 126)]
+#[ensures(result == (2 * (x + 1)))]
+fn right(x: u8) -> u8 {
+    (x + 1) * 2
+}

--- a/test_programs/formal_verify_success/struct/Nargo.toml
+++ b/test_programs/formal_verify_success/struct/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_struct"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/struct/src/main.nr
+++ b/test_programs/formal_verify_success/struct/src/main.nr
@@ -1,0 +1,7 @@
+struct A { x: u8, y: u8 }
+
+#[requires((a.x < 10) & (a.y < 10))]
+#[ensures((result.x == a.x + a.y) & (result.y == a.y))]
+fn main(a: A) -> pub A {
+	A { x: a.x + a.y, y: a.y }
+}

--- a/test_programs/formal_verify_success/tuples/Nargo.toml
+++ b/test_programs/formal_verify_success/tuples/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_tuples"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/tuples/src/main.nr
+++ b/test_programs/formal_verify_success/tuples/src/main.nr
@@ -1,0 +1,5 @@
+#[requires((x.0 < 10) & (x.2 < 10))]
+#[ensures((result.0 == x.0) & (result.2 == x.2 + x.0))]
+fn main(x: (u8, Field, u8)) -> pub (u8, Field, u8) {
+    (x.0, x.1, x.2 + x.0)
+}


### PR DESCRIPTION
With this fix we now fully support the use of the `result` variable inside of `ensures` attribute. This allows us to start moving tests here from the Noir FV prototype.
Tests whose name starts with `fv_attribute_` are tests for the semantic analysis which we do during the compilation phase of the code. 