### PR TITLE
feat(ast-passes): Add `fix_tuple_deconstruction` pass

### DIFF
--- a/compiler/noirc_evaluator/src/vir/mod.rs
+++ b/compiler/noirc_evaluator/src/vir/mod.rs
@@ -1,9 +1,12 @@
 use noirc_frontend::monomorphization::ast::Program;
 use vir::ast::Krate;
 use vir_gen::{BuildingKrateError, build_krate};
+
+use crate::vir::opt_passes::monomorph_ast_optimization_passes;
 pub mod vir_gen;
+pub mod opt_passes;
 
 pub fn create_verus_vir(program: Program) -> Result<Krate, BuildingKrateError> {
-    // let program = monomorph_ast_optimization_passes(program); // TODO(totel)
+    let program = monomorph_ast_optimization_passes(program);
     build_krate(program)
 }

--- a/compiler/noirc_evaluator/src/vir/opt_passes/mod.rs
+++ b/compiler/noirc_evaluator/src/vir/opt_passes/mod.rs
@@ -1,0 +1,10 @@
+use noirc_frontend::monomorphization::ast::Program;
+
+use crate::vir::opt_passes::tuple_deconstruction::fix_tuple_deconstruction_pass;
+pub mod tuple_deconstruction;
+
+
+pub fn monomorph_ast_optimization_passes(mut program: Program) -> Program {
+    fix_tuple_deconstruction_pass(&mut program);
+    program
+}

--- a/compiler/noirc_evaluator/src/vir/opt_passes/tuple_deconstruction.rs
+++ b/compiler/noirc_evaluator/src/vir/opt_passes/tuple_deconstruction.rs
@@ -1,0 +1,81 @@
+use noirc_frontend::monomorphization::ast::{
+    Expression, Function, Ident, Let, Program, Type,
+};
+
+pub fn fix_tuple_deconstruction_pass(program: &mut Program) {
+    program.functions.iter_mut().for_each(|function| fix_tuple_deconstruction(function));
+}
+
+fn fix_tuple_deconstruction(function: &mut Function) {
+    fix_tuple_deconstruction_expression(&mut function.body);
+}
+
+/// If the given `expression` is a block where:
+/// - The first expression is itself a block, and
+/// - The first statement inside that inner block is a `let _ = (tuple)`
+///
+/// Then:
+/// - This function rewrites the inner block, and
+/// - Afterwards flattens it into the outer block
+fn fix_tuple_deconstruction_expression(expression: &mut Expression) {
+    if let Expression::Block(outer_block) = expression {
+        let mut blocks_to_be_flattened: Vec<(usize, Vec<Expression>)> = Vec::new();
+
+        // NOTE: enumeration done beforehand to keep real original indices
+        outer_block
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(i, expression)| {
+                if let Expression::Block(inner_expressions) = expression {
+                    Some((i, inner_expressions))
+                } else {
+                    None
+                }
+            })
+            .for_each(|(i, expressions)| {
+                let let_exprs_for_deconstruct_tuple: Option<usize> = expressions
+                    .first()
+                    .and_then(|first_expression| match first_expression {
+                        Expression::Let(Let { name, expression, .. }) => Some((name, expression)),
+                        _ => None,
+                    })
+                    .and_then(
+                        |(name, expression)| if *name == "_" { Some(expression) } else { None },
+                    )
+                    .and_then(|expression| {
+                        let ty = expression.return_type()?;
+                        match ty.as_ref() {
+                            Type::Tuple(tuple_vec) => Some(tuple_vec.len()),
+                            _ => None,
+                        }
+                    });
+
+                if let Some(exprs_len) = let_exprs_for_deconstruct_tuple {
+                    for expr in expressions[1..=exprs_len].iter_mut() {
+                        assert!(matches!(expr, Expression::Let(..)), 
+                            "Expected to have a follow up auto generated let expressions after tuple deconstruct assignment");
+                        if let Expression::Let(let_expr) = expr {
+                            fix_rhs_tuple_indexing(let_expr);
+                        }
+                    }
+                    blocks_to_be_flattened.push((i, expressions.clone()));
+                }
+            });
+
+        // Flatten marked blocks into the outer block
+        let mut offset = 0;
+        blocks_to_be_flattened.into_iter().for_each(|(original_index, expressions)| {
+            let added_expressions_count = expressions.len();
+            outer_block.splice(original_index + offset..original_index + offset + 1, expressions);
+            offset = offset + added_expressions_count - 1;
+        });
+    }
+}
+
+fn fix_rhs_tuple_indexing(expr: &mut Let) {
+    if let Expression::ExtractTupleField(rhs_ident, _) = expr.expression.as_mut() {
+        if let Expression::Ident(Ident { name, .. }) = rhs_ident.as_mut() {
+            *name = String::from("_");
+        }
+    }
+}

--- a/test_programs/formal_verify_success/struct_return/Nargo.toml
+++ b/test_programs/formal_verify_success/struct_return/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_struct_return"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/struct_return/src/main.nr
+++ b/test_programs/formal_verify_success/struct_return/src/main.nr
@@ -1,0 +1,23 @@
+struct A {
+    x: u32,
+    y: u32,
+}
+
+#[requires(x < 1000)]
+#[ensures((result.x == x + 1) & (result.y == x + 2))]
+fn f(x: u32) -> A {
+    A { x: x + 1, y: x + 2 }
+}
+
+#[requires(x < 1000)]
+#[ensures((result.x == x + 2) & (result.y == x + 1))]
+fn g(x: u32) -> A {
+    let res = f(x);
+    A { x: res.y, y: res.x }
+}
+
+#[ensures(result == 13)]
+fn main() -> pub u32 {
+    let A { x, y } = g(5);
+    x + y
+}

--- a/test_programs/formal_verify_success/struct_return_basic/Nargo.toml
+++ b/test_programs/formal_verify_success/struct_return_basic/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_struct_return"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/struct_return_basic/src/main.nr
+++ b/test_programs/formal_verify_success/struct_return_basic/src/main.nr
@@ -1,0 +1,10 @@
+struct A {
+    x: u32,
+    y: u32,
+}
+
+#[ensures(result == 3)]
+fn main() -> pub u32 {
+    let A { x, y } = A {x: 1, y: 2};
+    x + y
+}

--- a/test_programs/formal_verify_success/tuple_deconstruct/Nargo.toml
+++ b/test_programs/formal_verify_success/tuple_deconstruct/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_tuple_return"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/tuple_deconstruct/src/main.nr
+++ b/test_programs/formal_verify_success/tuple_deconstruct/src/main.nr
@@ -1,0 +1,5 @@
+#[ensures(result == 1)]
+fn main() -> pub u32 {
+    let (a, b) = (1, 2);
+    a
+}

--- a/test_programs/formal_verify_success/tuple_deconstruct_2/Nargo.toml
+++ b/test_programs/formal_verify_success/tuple_deconstruct_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_tuple_return"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/tuple_deconstruct_2/src/main.nr
+++ b/test_programs/formal_verify_success/tuple_deconstruct_2/src/main.nr
@@ -1,0 +1,6 @@
+#[ensures(result == 5)]
+fn main() -> pub u32 {
+    let (a, b) = (1, 2);
+    let (c, d) = (3, 4);
+    a + d
+}

--- a/test_programs/formal_verify_success/tuple_return/Nargo.toml
+++ b/test_programs/formal_verify_success/tuple_return/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_tuple_return"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/tuple_return/src/main.nr
+++ b/test_programs/formal_verify_success/tuple_return/src/main.nr
@@ -1,0 +1,18 @@
+#[requires(x < 1000)]
+#[ensures((result.0 == x + 1) & (result.1 == x + 2) & (result.2 == x + 3))]
+fn f(x: u32) -> (u32, u32, u32) {
+    (x + 1, x + 2, x + 3)
+}
+
+#[requires(x < 1000)]
+#[ensures((result.0 == x + 3) & (result.1 == x + 1) & (result.2 == x + 2))]
+fn g(x: u32) -> (u32, u32, u32) {
+    let res = f(x);
+    (res.2, res.0, res.1)
+}
+
+#[ensures(result == 7)]
+fn main() -> pub u32 {
+    let (a, b, c) = g(5);
+    a + b - c
+}

--- a/test_programs/formal_verify_success/tuple_return_basic/Nargo.toml
+++ b/test_programs/formal_verify_success/tuple_return_basic/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fv_tuple_return"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/tuple_return_basic/src/main.nr
+++ b/test_programs/formal_verify_success/tuple_return_basic/src/main.nr
@@ -1,0 +1,11 @@
+#[requires(x < 1000)]
+#[ensures((result.0 == x + 1) & (result.1 == x + 2) & (result.2 == x + 3))]
+fn f(x: u32) -> (u32, u32, u32) {
+    (x + 1, x + 2, x + 3)
+}
+
+#[ensures(result == 5)]
+fn main() -> pub u32 {
+    let (a, b, c) = f(5);
+    a + b - c
+}


### PR DESCRIPTION
Added an optimization passes which fixes the "invalid" AST when we have a tuple deconstruction expression.

For more details check out the issue defined [here](https://coda.io/d/_d6vM0kjfQP6#PL-Team-Table-View_tueLahxO/r3179&view=center).