### PR TITLE
fix(quantifiers): Fix quantifier bugs

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -2458,6 +2458,7 @@ impl<'context> Elaborator<'context> {
         hir_func: &HirFunction,
         func_location: Location,
     ) {
+        self.in_specification_context = true;
         for attribute in fv_attributes {
             match attribute {
                 FormalVerificationAttribute::Ensures(ensures_attribute) => {
@@ -2504,6 +2505,7 @@ impl<'context> Elaborator<'context> {
                 }
             }
         }
+        self.in_specification_context = false;
     }
 
     /// Adds the function's return value to the variable scope with

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -128,6 +128,9 @@ impl Expression {
                 }
                 owned(Type::Tuple(types))
             }
+            // Quantifiers are of type boolean because they can be
+            // chained via logical operators like &, | and etc.
+            Expression::Quant(..) => owned(Type::Bool),
 
             Expression::For(_)
             | Expression::Loop(_)
@@ -138,8 +141,7 @@ impl Expression {
             | Expression::Semi(_)
             | Expression::Drop(_)
             | Expression::Break
-            | Expression::Continue
-            | Expression::Quant(..) => None,
+            | Expression::Continue => None,
         }
     }
 

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -573,7 +573,7 @@ impl AstPrinter {
         )?;
         self.print_expr(expr, f)?;
         write!(f, ")")?;
-        todo!()
+        Ok(())
     }
 }
 

--- a/test_programs/formal_verify_success/exists_big_element_sum/Nargo.toml
+++ b/test_programs/formal_verify_success/exists_big_element_sum/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "exists_big_element_sum"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/exists_big_element_sum/src/main.nr
+++ b/test_programs/formal_verify_success/exists_big_element_sum/src/main.nr
@@ -1,0 +1,11 @@
+#[requires(exists(|i| (0 <= i) & (i < 20) & arr[i] > 100))]
+#[ensures(result > 100)] 
+// We require that an element bigger than 100 exists in the array.
+// Therefore we expect the sum to be bigger than 100.
+fn main(arr: [u16; 20]) -> pub u64 {
+    let mut sum: u64 = 0;
+    for i in 0..20 {
+        sum += arr[i] as u64;
+    }
+    sum
+}

--- a/test_programs/formal_verify_success/exists_zero_in_array/Nargo.toml
+++ b/test_programs/formal_verify_success/exists_zero_in_array/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "exists_zero_in_array"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/exists_zero_in_array/src/main.nr
+++ b/test_programs/formal_verify_success/exists_zero_in_array/src/main.nr
@@ -1,0 +1,9 @@
+#[requires(exists(|i| (0 <= i) & (i < 7) & (arr[i] == 0)))]
+#[ensures(result == 0)]
+fn main(arr: [u8; 7]) -> pub u64 {
+    let mut mul: u64 = 1;
+    for i in 0..7 {
+        mul *= arr[i] as u64;
+    }
+    mul
+}

--- a/test_programs/formal_verify_success/forall_max_is_max/Nargo.toml
+++ b/test_programs/formal_verify_success/forall_max_is_max/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "forall_max_is_max"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/forall_max_is_max/src/main.nr
+++ b/test_programs/formal_verify_success/forall_max_is_max/src/main.nr
@@ -1,0 +1,5 @@
+#[requires(forall(|i, j| (0 <= i) & (i < j) & (j < 15) ==> v[i] <= v[j]))]
+#[ensures(forall(|i| (0 <= i) & (i < 15) ==> v[i] <= result))]
+fn main(v: [u64; 15], k: u64) -> pub u64 {
+    v[14] // The array is sorted and this is the last element, therefore it's the maximum element.  
+}

--- a/test_programs/formal_verify_success/forall_structure/Nargo.toml
+++ b/test_programs/formal_verify_success/forall_structure/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "temp_name"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/forall_structure/src/main.nr
+++ b/test_programs/formal_verify_success/forall_structure/src/main.nr
@@ -1,0 +1,8 @@
+struct A {
+  id: Field,
+  balance: u32,
+}
+#[requires(forall(|i, j| (0 <= i) & (i < j) & (j < 2) 
+                ==> x[i].id != x[j].id))]
+fn main(x: [A; 2]) {}
+

--- a/test_programs/formal_verify_success/forall_sum_of_evens/Nargo.toml
+++ b/test_programs/formal_verify_success/forall_sum_of_evens/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "forall_sum_of_evens"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/forall_sum_of_evens/src/main.nr
+++ b/test_programs/formal_verify_success/forall_sum_of_evens/src/main.nr
@@ -1,0 +1,12 @@
+#[requires(forall(|i| (0 <= i) & (i < 10) ==> arr[i] % 2 == 0) 
+            & forall(|i| (0 <= i) & (i < 10) ==> arr[i] < 100) )]
+#[ensures((result % 2 == 0) & (result < 1000))]
+// The sum of an array which constist of even elements upper bounded by 100
+// will be even and upper bounded by 1000
+fn main(arr: [u32; 10]) -> pub u32 {
+    let mut sum = 0;
+    for i in 0..10 {
+        sum += arr[i];
+    }
+    sum
+}


### PR DESCRIPTION
We now enable the specification context flag while elaborating FV annotations. If this flag is set to `false` we produce errors when we encounter quantifiers.
Removed an old `todo!()` which was forgotten.
Specified that the return type of a quantifier expression is boolean.

Added multiple tests which previously didn't pass because of aforementioned bugs.