### PR TITLE
fix(mut-args): Convert mut args to non mut

### DIFF
--- a/compiler/noirc_evaluator/src/vir/opt_passes/mod.rs
+++ b/compiler/noirc_evaluator/src/vir/opt_passes/mod.rs
@@ -1,16 +1,17 @@
 use noirc_frontend::monomorphization::ast::Program;
 
 use crate::vir::opt_passes::{
-    array_mutation::fix_array_mutation_pass, loop_unroll::unroll_for_loops_pass,
-    tuple_deconstruction::fix_tuple_deconstruction_pass,
+    array_mutation::fix_array_mutation_pass, loop_unroll::unroll_for_loops_pass, mut_args::demut_parameters, tuple_deconstruction::fix_tuple_deconstruction_pass
 };
 pub mod array_mutation;
 pub mod loop_unroll;
 pub mod tuple_deconstruction;
+pub mod mut_args;
 
 pub fn monomorph_ast_optimization_passes(mut program: Program) -> Program {
     fix_tuple_deconstruction_pass(&mut program);
     unroll_for_loops_pass(&mut program);
     fix_array_mutation_pass(&mut program);
+    demut_parameters(&mut program);
     program
 }

--- a/compiler/noirc_evaluator/src/vir/opt_passes/mut_args.rs
+++ b/compiler/noirc_evaluator/src/vir/opt_passes/mut_args.rs
@@ -1,0 +1,91 @@
+//! Verus performs a transformation on function parameters where mutable arguments are
+//! converted into immutable ones, and a `let mut` binding is inserted at the beginning
+//! of the function body. To stay consistent with this behavior, we apply the same
+//! transformation during our monomorphized AST passes.
+//!
+//! Specifically, the function:
+//! ```
+//! fn foo(mut x: T) {
+//!     ...
+//! }
+//! ```
+//! is transformed into:
+//! ```
+//! fn foo(x: T) {
+//!     let mut x = x;
+//!     ...
+//! }
+//! ```
+//!
+//! In short, `mut` is removed from the parameter list, and a mutable shadowing
+//! `let` binding is inserted at the top of the function body.
+
+use noirc_errors::Location;
+use noirc_frontend::{
+    hir_def::stmt::HirPattern,
+    monomorphization::ast::{Definition, Expression, Function, Ident, IdentId, Let, Program},
+};
+
+pub fn demut_parameters(program: &mut Program) {
+    program.functions.iter_mut().for_each(demut_parameters_inner);
+}
+
+fn demut_parameters_inner(function: &mut Function) {
+    insert_let_mut_exprs(function);
+    convert_mut_params_to_non_mut(function)
+}
+
+fn insert_let_mut_exprs(function: &mut Function) {
+    let mut_params_locations: Vec<Option<Location>> = function
+        .func_sig
+        .0
+        .iter()
+        .map(|(hir_pattern, ..)| match hir_pattern {
+            HirPattern::Mutable(_, location) => Some(*location),
+            _ => None,
+        })
+        .collect();
+
+    function
+        .parameters
+        .iter()
+        .zip(mut_params_locations)
+        .filter(|(param, _)| param.1) // is mut
+        // Get parameter's local id, name, type and location
+        .map(|(param, location)| (param.0, param.2.clone(), param.3.clone(), location))
+        .rev()
+        .for_each(|(local_id, param_name, param_type, location)| {
+            // Insert `let` expression at the start of the body's block
+            if let Expression::Block(block) = &mut function.body {
+                block.insert(
+                    0,
+                    Expression::Let(Let {
+                        id: local_id,
+                        mutable: true,
+                        name: param_name.clone(),
+                        expression: Box::new(Expression::Ident(Ident {
+                            location,
+                            definition: Definition::Local(local_id),
+                            mutable: false,
+                            name: param_name,
+                            typ: param_type,
+                            id: IdentId(local_id.0),
+                        })),
+                    }),
+                );
+            }
+        });
+}
+
+fn convert_mut_params_to_non_mut(function: &mut Function) {
+    function.parameters.iter_mut().for_each(|param| {
+        param.1 = false; // Set mut to false 
+    });
+
+    function.func_sig.0.iter_mut().for_each(|param| {
+        if let HirPattern::Mutable(ref inner, _) = param.0 {
+            // Clone gets optimized away
+            param.0 = *inner.clone()
+        }
+    });
+}

--- a/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/params.rs
+++ b/compiler/noirc_evaluator/src/vir/vir_gen/expr_to_vir/params.rs
@@ -25,7 +25,7 @@ pub fn ast_param_to_vir_param(
         name: ast_var_into_var_ident(parameter.2.clone(), parameter.0.0),
         typ: ast_type_to_vir_type(&parameter.3),
         mode,
-        is_mut: parameter.1,
+        is_mut: is_param_mut(&parameter.3),
         unwrapped_info: None, // Special unwrapping pattern which we don't support
     };
 
@@ -33,4 +33,8 @@ pub fn ast_param_to_vir_param(
         build_span_no_id(format!("Parameters of the function {}", function_name), Some(location)),
         paramx,
     )
+}
+
+fn is_param_mut(ast_type: &Type) -> bool {
+    matches!(ast_type, Type::Reference(_, true))
 }

--- a/test_programs/formal_verify_success/call_struct_method/Nargo.toml
+++ b/test_programs/formal_verify_success/call_struct_method/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "return_self_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/call_struct_method/src/main.nr
+++ b/test_programs/formal_verify_success/call_struct_method/src/main.nr
@@ -1,0 +1,17 @@
+struct A {
+  id: Field,
+  balance: u32
+}
+
+impl A {
+    #[ensures(result.balance == self.balance / 2)]
+    fn foo(mut self) -> Self {
+        self.balance = self.balance / 2;
+        self
+    }
+}
+
+fn main(x: A) -> pub A {
+    x.foo()
+}
+

--- a/test_programs/formal_verify_success/fv_std_old/Nargo.toml
+++ b/test_programs/formal_verify_success/fv_std_old/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fv_std_old"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]
+fv_std = { path = "../../../fv_std" }

--- a/test_programs/formal_verify_success/fv_std_old/src/main.nr
+++ b/test_programs/formal_verify_success/fv_std_old/src/main.nr
@@ -1,0 +1,16 @@
+use fv_std::old;
+
+#[requires(x == 4)]
+#[ensures(result == 5)]
+fn main(mut x: u32) -> pub u32 {
+  foo(&mut x);
+  x
+}
+
+#[requires(*old(x) == 4)]
+#[ensures(*x == *old(x) + 1)]
+fn foo(x: &mut u32) {
+  *x = *x + 1;
+}
+
+

--- a/test_programs/formal_verify_success/mutate_array_of_tuples/Nargo.toml
+++ b/test_programs/formal_verify_success/mutate_array_of_tuples/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "array_set_tuple_case"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/mutate_array_of_tuples/src/main.nr
+++ b/test_programs/formal_verify_success/mutate_array_of_tuples/src/main.nr
@@ -1,0 +1,7 @@
+#[requires(x[3].0 == -2)]
+#[requires(i < 5)]
+#[ensures(result[i].1 == y)]
+fn main(mut x: [(i32, u32); 5], i: u32, y: u32) -> pub [(i32, u32); 5] {
+    x[i].1 = y;
+    x
+}


### PR DESCRIPTION
Verus performs a transformation on function parameters where mutable arguments are converted into immutable ones, and a `let` mut binding is inserted at the beginning of the function body. To stay consistent with this behavior, we apply the same transformation during our monomorphized AST passes.

Added a test which shows off how the function `old()` from `fv_std` lib works.
Added two more tests which previously didn't pass.