### PR TITLE
chore(typing): Fetch min available local id

### DIFF
--- a/compiler/formal_verification/src/lib.rs
+++ b/compiler/formal_verification/src/lib.rs
@@ -14,11 +14,12 @@ pub mod ast;
 pub mod parse;
 pub mod typing;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct State<'a> {
     pub function: &'a mast::Function,
     pub global_constants: &'a BTreeMap<mast::GlobalId, (String, mast::Type, mast::Expression)>,
     pub functions: &'a BTreeMap<mast::FuncId, mast::Function>,
+    pub min_local_id: &'a mut u32,
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/formal_verification/src/parse.rs
+++ b/compiler/formal_verification/src/parse.rs
@@ -834,7 +834,7 @@ pub mod tests {
                         Visibility::Public,
                     ),
                     (
-                        LocalId(3),
+                        LocalId(4),
                         false,
                         "user".to_string(),
                         NoirType::Tuple(vec![NoirType::Bool, NoirType::Unit]),
@@ -874,6 +874,7 @@ pub mod tests {
                 .into_iter()
                 .collect(),
             )),
+            min_local_id: Box::leak(Box::new(5)),
         }
     }
 

--- a/compiler/formal_verification/src/typing.rs
+++ b/compiler/formal_verification/src/typing.rs
@@ -141,7 +141,7 @@ pub fn propagate_concrete_type(
     })
 }
 
-pub fn type_infer(state: State, expr: SpannedExpr) -> Result<SpannedTypedExpr, TypeInferenceError> {
+pub fn type_infer(state: &State, expr: SpannedExpr) -> Result<SpannedTypedExpr, TypeInferenceError> {
     // NOTE: predicate, always bool,
     //       assume subterms are `u32` (like `Noir` does)
     let default_literal_type = NoirType::Integer(Signedness::Unsigned, IntegerBitSize::ThirtyTwo);
@@ -642,7 +642,7 @@ mod tests {
         )
         .unwrap();
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let spanned_typed_expr = type_infer(state, spanned_expr).unwrap();
+        let spanned_typed_expr = type_infer(&state, spanned_expr).unwrap();
         assert!(
             cata(spanned_typed_expr, &|(_, expr_type), expr| {
                 match expr {
@@ -680,7 +680,7 @@ mod tests {
         )
         .unwrap();
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let spanned_typed_expr = type_infer(state, spanned_expr).unwrap();
+        let spanned_typed_expr = type_infer(&state, spanned_expr).unwrap();
         assert!(
             cata(spanned_typed_expr.clone(), &|(_, expr_type), expr| {
                 match expr {
@@ -746,7 +746,7 @@ mod tests {
         )
         .unwrap();
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let spanned_typed_expr = type_infer(state, spanned_expr).unwrap();
+        let spanned_typed_expr = type_infer(&state, spanned_expr).unwrap();
         dbg!(&spanned_typed_expr);
         assert_eq!(spanned_typed_expr.ann.1, NoirType::Bool);
     }
@@ -764,7 +764,7 @@ mod tests {
         )
         .unwrap();
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let type_inference_error = type_infer(state, spanned_expr).unwrap_err();
+        let type_inference_error = type_infer(&state, spanned_expr).unwrap_err();
         let TypeInferenceError::NoirTypeError(TypeCheckError::TypeMismatch {
             expected_typ,
             expr_typ,
@@ -794,7 +794,7 @@ mod tests {
         )
         .unwrap();
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let type_inference_error = type_infer(state, spanned_expr).unwrap_err();
+        let type_inference_error = type_infer(&state, spanned_expr).unwrap_err();
         let TypeInferenceError::IntegerLiteralDoesNotFit {
             literal: _,
             literal_type,
@@ -828,7 +828,7 @@ mod tests {
         )
         .unwrap();
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let spanned_typed_expr = type_infer(state, spanned_expr).unwrap();
+        let spanned_typed_expr = type_infer(&state, spanned_expr).unwrap();
         dbg!(&spanned_typed_expr);
         assert_eq!(spanned_typed_expr.ann.1, NoirType::Bool);
     }
@@ -846,7 +846,7 @@ mod tests {
         )
         .unwrap();
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let spanned_typed_expr = type_infer(state, spanned_expr).unwrap();
+        let spanned_typed_expr = type_infer(&state, spanned_expr).unwrap();
         dbg!(&spanned_typed_expr);
         assert_eq!(spanned_typed_expr.ann.1, NoirType::Bool);
     }
@@ -868,7 +868,7 @@ mod tests {
         .unwrap();
 
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let spanned_typed_expr = type_infer(state, spanned_expr).unwrap();
+        let spanned_typed_expr = type_infer(&state, spanned_expr).unwrap();
         dbg!(&strip_ann(spanned_typed_expr));
         // assert_eq!(spanned_typed_expr.ann.1, NoirType::Bool);
     }
@@ -886,7 +886,7 @@ mod tests {
         )
         .unwrap();
         let Attribute::Ensures(spanned_expr) = attribute else { panic!() };
-        let type_inference_error = type_infer(state, spanned_expr).unwrap_err();
+        let type_inference_error = type_infer(&state, spanned_expr).unwrap_err();
         let TypeInferenceError::MonomorphizationRequest(MonomorphizationRequest {
             function_identifier,
             param_types,


### PR DESCRIPTION
We are now passing this value to `type_infer` which in return will attach ids to quantifier indices.

Expanded the `State` structure and removed its `Clone` trait.