### PR TITLE
feat(annotations): Type infer args in func calls

### DIFF
--- a/compiler/formal_verification/src/typing.rs
+++ b/compiler/formal_verification/src/typing.rs
@@ -373,10 +373,10 @@ pub fn type_infer(
                     variable_type
                 }
                 ExprF::FnCall { name, args } => {
-                    let return_type = state
+                    let func_object = state
                         .functions
                         .iter()
-                        .find_map(|(_, func)| (func.name == *name).then_some(&func.return_type))
+                        .find_map(|(_, func)| (func.name == *name).then_some(func))
                         .ok_or(TypeInferenceError::MonomorphizationRequest(
                             MonomorphizationRequest {
                                 function_identifier: name.clone(),
@@ -387,7 +387,14 @@ pub fn type_infer(
                             },
                         ))?;
 
-                    OptionalType::Well(return_type.clone())
+                    // Unify the function call arguments with their expected type
+                    for (arg, (_id, _mut, _name, typ, _visibility)) in
+                        args.iter_mut().zip(&func_object.parameters)
+                    {
+                        arg.unify_with_type(typ.clone())?;
+                    }
+
+                    OptionalType::Well(func_object.return_type.clone())
                 }
                 ExprF::Quantified { variables, .. } => {
                     variables

--- a/test_programs/formal_verify_success/func_call_in_annotation/Nargo.toml
+++ b/test_programs/formal_verify_success/func_call_in_annotation/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "func_call_in_annotation"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/formal_verify_success/func_call_in_annotation/src/main.nr
+++ b/test_programs/formal_verify_success/func_call_in_annotation/src/main.nr
@@ -1,0 +1,7 @@
+#['ensures(foo(5))]
+fn main() {}
+
+#['ghost]
+fn foo(x: u16) -> bool {
+  true
+}


### PR DESCRIPTION
We now unify the types of the args of each function call with the types of the function's signature.

Added a test which now passes successfully because we now assign type `u16` to the integer literal `5`.